### PR TITLE
release: 0.7.4 — Pack Engineering availability (docs-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.4] — 2026-05-19 — Pack Engineering availability (docs-only)
+
+Documents the availability of the **Pack Engineering (PE)** module that
+shipped in `streamtex-claude` 0.3.0. No library code changes — this release
+exists so the streamtex library's own `.claude/references/` cheatsheet and
+README stay in sync with the broader ecosystem.
+
+### Changed
+
+- `README.md` — "AI-Powered Features" section updated to reference
+  `stx-pe` (7 commands) alongside `stx-block` and `stx-ce`. New
+  "Pack Engineering (`/stx-pe`)" subsection. `pack-orchestrator` added
+  to the AI Agents table.
+- The local `.claude/references/streamtex_cheatsheet_en.md` and
+  `.claude/references/pe_cheatsheet_en.md` files are synced from the
+  `streamtex-claude` 0.3.0 source via `stx claude update`. They are
+  gitignored by design (`.claude/*` is managed by the profile
+  installer, not by git).
+
+### About the PE module
+
+PE is a Claude-driven orchestrated lifecycle for extracting, forking,
+refining, auditing, adopting, and publishing reuse packs across N
+projects. It drives the deterministic `stx component / pack / kit / validate`
+CLI commands (which already exist in `streamtex 0.7.x`) and adds the
+AI-assisted analysis, design, and retrofit phases that those commands
+cannot perform deterministically.
+
+The module itself ships in **streamtex-claude 0.3.0** as a project-profile
+sub-directory (`profiles/project/pack-engineering/`) and is installed by
+`stx claude install project <target>`. No `streamtex` library changes
+are required to use PE.
+
 ## [0.7.3] — 2026-05-19 (L5 — TOCConfig.numerate_titles removed)
 
 Final piece of the Q10 legacy purge: the `numerate_titles` field on

--- a/README.md
+++ b/README.md
@@ -276,9 +276,9 @@ uv add "streamtex[cli]"          # stx CLI (already installed as a global tool a
 
 ## AI-Powered Features
 
-StreamTeX ships with the **stx-block** (15 commands) and **stx-ce** (13 commands)
-slash command groups, **3 specialized agents**, and **4 project templates**
-for AI-assisted development.
+StreamTeX ships with the **stx-block** (15 commands), **stx-ce** (14 commands),
+and **stx-pe** (7 commands) slash command groups, **specialized agents**, and
+**4 project templates** for AI-assisted development.
 
 ### Project Creation & Customization
 
@@ -309,6 +309,20 @@ for AI-assisted development.
 | `/stx-import:html-batch` | Batch conversion of multiple files |
 | `/stx-import:html-audit` | Audit conversion quality |
 
+### Pack Engineering (`/stx-pe`) — orchestrated pack lifecycle
+
+| Command | What it does |
+|---------|-------------|
+| `/stx-pe:go` | Auto-detect sub-mode (bootstrap / specialize / refine / audit / adopt / publish) |
+| `/stx-pe:bootstrap <projects>` | Extract a brand-new pack from N projects |
+| `/stx-pe:specialize <upstream> <projects>` | Fork an upstream pack with domain extensions |
+| `/stx-pe:refine` | Incrementally enrich the active pack with new patterns |
+| `/stx-pe:audit <pack>` | Read-only health audit (unused / duplicates / drift) |
+| `/stx-pe:adopt <pack> <projects>` | Install pack in N projects without extraction |
+| `/stx-pe:publish <pack>` | Release a mature pack (semver + tag + optional PyPI) |
+
+Single user-facing **`pack-orchestrator`** agent delegates to six invisible specialists; 4 validation gates (G1–G4). PE drives the deterministic `stx component / pack / kit` CLI commands and adds AI-assisted analysis, design, and retrofit.
+
 ### AI Agents
 
 | Agent | Role |
@@ -316,6 +330,7 @@ for AI-assisted development.
 | **Project Architect** | Designs project structure from natural language |
 | **Slide Designer** | Creates pedagogically structured, polished slides |
 | **Slide Reviewer** | Reviews and validates completed slides |
+| **Pack Orchestrator** | THE single user-facing PE agent — bootstrap / specialize / refine / audit / adopt / publish |
 | **Presentation Designer** | Specialist for live projection (large fonts, minimal text) |
 
 See the **[AI Guide](https://github.com/nicolasguelfi/streamtex/blob/main/AI_GUIDE.md)** for the complete reference.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "streamtex"
-version = "0.7.3"
+version = "0.7.4"
 description = "AI-powered content framework for Streamlit — create presentations, courses, and web-books with Claude or Cursor, no coding required."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Docs-only patch release that documents the **Pack Engineering (PE)** module shipping in `streamtex-claude` 0.3.0.

No library code changes — version bump exists so the README + CHANGELOG stay in sync with the broader ecosystem release.

## Changes
- \`pyproject.toml\`: 0.7.3 → 0.7.4
- \`CHANGELOG.md\`: new 0.7.4 entry documenting PE availability
- \`README.md\`: \"AI-Powered Features\" updated to reference \`stx-pe\` (7 commands) alongside \`stx-block\` and \`stx-ce\`; new \"Pack Engineering (\`/stx-pe\`)\" subsection; \`pack-orchestrator\` added to the AI Agents table

## Companion PRs
- streamtex-claude#18 — PE module (28 new files + coherence pass)
- streamtex-docs#8 — 4 documentation blocks + ecosystem cross-references

## Test plan
- [x] Local pyproject.toml parses and validates.
- [ ] Tag + PyPI publish after merge (will happen in a separate step).
- [ ] Update \`streamtex-docs/.stx-version\` to 0.7.4 before Hetzner deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)