### PR TITLE
Audit 2026-05-23: library hygiene + --prune flag + CLI deduplication

### DIFF
--- a/streamtex/__init__.py
+++ b/streamtex/__init__.py
@@ -35,7 +35,7 @@ try:
     __version__ = _pkg_version("streamtex")
 
     # Core style system
-    from .styles import Style, ListStyle, StyleGrid, StxStyles, StreamTeX_Styles, theme
+    from .styles import Style, ListStyle, StyleGrid, StxStyles, theme
 
     # Indexed responsive font scale (Layer 1 API)
     from .styles.scale import ScaleConfig, ScaleCurve, compute_scale, emit_scale_css

--- a/streamtex/book.py
+++ b/streamtex/book.py
@@ -345,7 +345,10 @@ def _offer_export_downloads(html: str, base_name: str,
                                 count=1,
                             )
                     except Exception:
-                        pass  # fallback to raw HTML
+                        # Title-enrichment is cosmetic: if the regex substitution
+                        # raises (malformed HTML, encoding issue), keep the
+                        # original html_download untouched and continue.
+                        pass
 
                 collector = get_asset_collector()
                 if collector:

--- a/streamtex/cli/_shared.py
+++ b/streamtex/cli/_shared.py
@@ -1,0 +1,70 @@
+"""Shared CLI helpers used by several command modules.
+
+Private module (underscore-prefixed) — not part of the public API.
+Consumers: pack_cmd, component_cmd, ds_cmd, kit_cmd, dev_cmd, validate_cmd.
+
+Function names keep their leading underscore so call sites in the
+consumer modules can stay unchanged after the refactor.
+"""
+
+from pathlib import Path
+
+import click
+
+
+def _find_project_dir() -> Path:
+    """Return the cwd if it contains pyproject.toml, else raise ClickException.
+
+    Used by every `stx` subcommand that operates on a StreamTeX project
+    (pack / component / ds / kit / dev / validate).
+    """
+    cwd = Path.cwd()
+    if (cwd / "pyproject.toml").is_file():
+        return cwd
+    raise click.ClickException(
+        "No pyproject.toml in current directory. Run from a StreamTeX project root."
+    )
+
+
+def _resolve_local_pack_dir(
+    project_dir: Path, pack_name: str | None
+) -> tuple[str, Path]:
+    """Return (pack_name, filesystem_path) for a writable local pack.
+
+    Refuses non-local packs (git remote / pypi) and packs not declared in
+    stx.toml. Falls back to the primary local pack when ``pack_name`` is None.
+    """
+    from streamtex.core import discovery
+
+    from . import _stx_toml
+
+    stx_toml = project_dir / "stx.toml"
+    if pack_name is None:
+        primary = discovery.get_primary_local_pack(
+            stx_toml if stx_toml.is_file() else None
+        )
+        if primary is None:
+            raise click.ClickException(
+                "No primary local pack declared in stx.toml. "
+                "Run `stx pack new <name>` then `stx pack set-primary <name>`."
+            )
+        target_name = primary["name"]
+        target_path = Path(primary["path"])
+    else:
+        entries = _stx_toml.list_packs(project_dir)
+        match = next((e for e in entries if e.get("name") == pack_name), None)
+        if match is None:
+            raise click.ClickException(
+                f"Pack '{pack_name}' is not declared in stx.toml. "
+                f"Run `stx pack new {pack_name}` or `stx pack add ...` first."
+            )
+        if match.get("type") != "local":
+            raise click.ClickException(
+                f"Pack '{pack_name}' is type='{match.get('type')}'; scaffolding only "
+                "supported in local packs. Clone the remote pack locally first."
+            )
+        target_name = pack_name
+        target_path = Path(match.get("path") or pack_name)
+    if not target_path.is_absolute():
+        target_path = (project_dir / target_path).resolve()
+    return target_name, target_path

--- a/streamtex/cli/claude_cmd.py
+++ b/streamtex/cli/claude_cmd.py
@@ -748,10 +748,11 @@ def _update_single_target(
     target: str,
     force: bool,
     console,
+    prune: bool = False,
 ) -> int:
     """Update a single target from its profile source.
 
-    Returns the number of files updated.
+    Returns the number of files updated (additions/modifications + prunes).
     """
     diffs = compare_profile(claude_repo, profile, target)
     source_files = collect_source_files(claude_repo, profile)
@@ -775,11 +776,36 @@ def _update_single_target(
 
     updated: list[str] = []
     skipped: list[str] = []
+    pruned: list[str] = []
+
+    # Paths that must NEVER be pruned even when --prune is set.
+    # .backup/ holds prior overwrite backups; .stx-profile is the
+    # profile marker (already filtered out by compare_profile, kept
+    # here as defense in depth).
+    backup_prefix = os.path.join(".claude", ".backup")
 
     for d in diffs:
         if d.status == "identical":
             continue
         if d.status == "extra":
+            if not prune:
+                continue
+            # Skip protected paths even under --prune.
+            if d.path.startswith(backup_prefix + os.sep) or d.path == backup_prefix:
+                continue
+            if d.path == os.path.join(".claude", ".stx-profile"):
+                continue
+            abs_path = os.path.join(target, d.path)
+            try:
+                # Make writable in case it was set 0o444 by a prior install
+                if os.path.isfile(abs_path):
+                    os.chmod(abs_path, 0o644)
+                os.remove(abs_path)
+                pruned.append(d.path)
+            except OSError as exc:
+                console.print(
+                    f"  [yellow]⚠[/yellow] Could not prune {d.path}: {exc}"
+                )
             continue
 
         # Preserve locally modified files unless --force
@@ -841,7 +867,16 @@ def _update_single_target(
         for f in skipped:
             console.print(f"  [yellow]\u25cb[/yellow] {f}")
 
-    return len(updated)
+    if pruned:
+        console.print(
+            f"\n[cyan]Pruned {len(pruned)} orphan file(s).[/cyan]\n"
+            "  These files were installed by a prior profile version but are "
+            "no longer declared in any manifest."
+        )
+        for f in pruned:
+            console.print(f"  [cyan]\u2212[/cyan] {f}")
+
+    return len(updated) + len(pruned)
 
 
 # ---------------------------------------------------------------------------
@@ -884,7 +919,14 @@ def diff_cmd(path: str) -> None:
     "--all", "update_all", is_flag=True,
     help="Update all projects in the workspace.",
 )
-def update_cmd(path: str, force: bool, update_all: bool) -> None:
+@click.option(
+    "--prune", is_flag=True,
+    help=(
+        "Remove orphan files in .claude/ that no manifest declares anymore. "
+        "Skips .claude/custom/, .claude/.backup/, and .claude/.stx-profile."
+    ),
+)
+def update_cmd(path: str, force: bool, update_all: bool, prune: bool) -> None:
     """Update an installed Claude profile from the source repo."""
     console = get_console()
 
@@ -907,7 +949,7 @@ def update_cmd(path: str, force: bool, update_all: bool) -> None:
             rel = os.path.relpath(target_path, ws_root)
             console.print(f"\n[bold cyan]\u2500\u2500 {rel} [/bold cyan]([cyan]{profile}[/cyan])")
             total_updated += _update_single_target(
-                claude_repo, profile, target_path, force, console,
+                claude_repo, profile, target_path, force, console, prune=prune,
             )
 
         separator = "\u2500" * 40
@@ -926,7 +968,7 @@ def update_cmd(path: str, force: bool, update_all: bool) -> None:
     # Single target mode
     _ws_root, claude_repo, profile, target = _resolve_profile_context(path)
     console.print(f"[cyan]Profile:[/cyan] {profile}")
-    _update_single_target(claude_repo, profile, target, force, console)
+    _update_single_target(claude_repo, profile, target, force, console, prune=prune)
 
 
 @click.command("check")

--- a/streamtex/cli/component_cmd.py
+++ b/streamtex/cli/component_cmd.py
@@ -13,18 +13,10 @@ from typing import Literal
 import click
 
 from . import _stx_toml
+from ._shared import _find_project_dir
 from .console import get_console
 
 DestinationClass = Literal["primary_local", "secondary_local_with_git", "git_remote", "pypi"]
-
-
-def _find_project_dir() -> Path:
-    cwd = Path.cwd()
-    if (cwd / "pyproject.toml").is_file():
-        return cwd
-    raise click.ClickException(
-        "No pyproject.toml in current directory. Run from a StreamTeX project root."
-    )
 
 
 def _classify_destination(entry: dict) -> DestinationClass:

--- a/streamtex/cli/component_cmd.py
+++ b/streamtex/cli/component_cmd.py
@@ -165,7 +165,12 @@ def find_cmd(query: str) -> None:
 @component.command("new")
 @click.argument("name")
 @click.option("--pack", "pack_name", default=None, help="Destination pack (default: primary local).")
-@click.option("--granularity", default="primitive", type=click.Choice(["primitive", "composition", "block"]))
+@click.option(
+    "--granularity",
+    default="primitive",
+    type=click.Choice(["primitive", "composition", "block"]),
+    help="Component granularity (default: primitive).",
+)
 def new_cmd(name: str, pack_name: str | None, granularity: str) -> None:
     """Scaffold a new component in the chosen (or primary local) pack."""
     from streamtex.core import discovery

--- a/streamtex/cli/dev_cmd.py
+++ b/streamtex/cli/dev_cmd.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import click
 
+from ._shared import _find_project_dir
 from .console import get_console
 from .dev_config import (
     REPOS,
@@ -16,17 +17,6 @@ from .dev_config import (
     validate_repo_name,
     validate_repo_path,
 )
-
-
-def _find_project_dir() -> Path:
-    """Return the project directory (cwd must contain pyproject.toml)."""
-    cwd = Path.cwd()
-    if (cwd / "pyproject.toml").is_file():
-        return cwd
-    raise click.ClickException(
-        "No pyproject.toml in current directory. "
-        "Run this command from a StreamTeX project root."
-    )
 
 
 def _ensure_gitignore(project_dir: Path) -> None:

--- a/streamtex/cli/ds_cmd.py
+++ b/streamtex/cli/ds_cmd.py
@@ -8,52 +8,8 @@ from pathlib import Path
 import click
 
 from . import _stx_toml
+from ._shared import _find_project_dir, _resolve_local_pack_dir
 from .console import get_console
-
-
-def _find_project_dir() -> Path:
-    cwd = Path.cwd()
-    if (cwd / "pyproject.toml").is_file():
-        return cwd
-    raise click.ClickException("No pyproject.toml in current directory.")
-
-
-def _resolve_local_pack_dir(project_dir: Path, pack_name: str | None) -> tuple[str, Path]:
-    """Return (pack_name, filesystem_path) for a writable local pack.
-
-    Refuses non-local packs (git remote / pypi) and packs not declared in stx.toml.
-    Falls back to the primary local pack when ``pack_name`` is None.
-    """
-    from streamtex.core import discovery
-
-    stx_toml = project_dir / "stx.toml"
-    if pack_name is None:
-        primary = discovery.get_primary_local_pack(stx_toml if stx_toml.is_file() else None)
-        if primary is None:
-            raise click.ClickException(
-                "No primary local pack declared in stx.toml. "
-                "Run `stx pack new <name>` then `stx pack set-primary <name>`."
-            )
-        target_name = primary["name"]
-        target_path = Path(primary["path"])
-    else:
-        entries = _stx_toml.list_packs(project_dir)
-        match = next((e for e in entries if e.get("name") == pack_name), None)
-        if match is None:
-            raise click.ClickException(
-                f"Pack '{pack_name}' is not declared in stx.toml. "
-                f"Run `stx pack new {pack_name}` or `stx pack add ...` first."
-            )
-        if match.get("type") != "local":
-            raise click.ClickException(
-                f"Pack '{pack_name}' is type='{match.get('type')}'; scaffolding only "
-                "supported in local packs. Clone the remote pack locally first."
-            )
-        target_name = pack_name
-        target_path = Path(match.get("path") or pack_name)
-    if not target_path.is_absolute():
-        target_path = (project_dir / target_path).resolve()
-    return target_name, target_path
 
 
 @click.group()

--- a/streamtex/cli/kit_cmd.py
+++ b/streamtex/cli/kit_cmd.py
@@ -8,52 +8,8 @@ from pathlib import Path
 import click
 
 from . import _stx_toml
+from ._shared import _find_project_dir, _resolve_local_pack_dir
 from .console import get_console
-
-
-def _find_project_dir() -> Path:
-    cwd = Path.cwd()
-    if (cwd / "pyproject.toml").is_file():
-        return cwd
-    raise click.ClickException("No pyproject.toml in current directory.")
-
-
-def _resolve_local_pack_dir(project_dir: Path, pack_name: str | None) -> tuple[str, Path]:
-    """Return (pack_name, filesystem_path) for a writable local pack.
-
-    Refuses non-local packs (git remote / pypi) and packs not declared in stx.toml.
-    Falls back to the primary local pack when ``pack_name`` is None.
-    """
-    from streamtex.core import discovery
-
-    stx_toml = project_dir / "stx.toml"
-    if pack_name is None:
-        primary = discovery.get_primary_local_pack(stx_toml if stx_toml.is_file() else None)
-        if primary is None:
-            raise click.ClickException(
-                "No primary local pack declared in stx.toml. "
-                "Run `stx pack new <name>` then `stx pack set-primary <name>`."
-            )
-        target_name = primary["name"]
-        target_path = Path(primary["path"])
-    else:
-        entries = _stx_toml.list_packs(project_dir)
-        match = next((e for e in entries if e.get("name") == pack_name), None)
-        if match is None:
-            raise click.ClickException(
-                f"Pack '{pack_name}' is not declared in stx.toml. "
-                f"Run `stx pack new {pack_name}` or `stx pack add ...` first."
-            )
-        if match.get("type") != "local":
-            raise click.ClickException(
-                f"Pack '{pack_name}' is type='{match.get('type')}'; scaffolding only "
-                "supported in local packs. Clone the remote pack locally first."
-            )
-        target_name = pack_name
-        target_path = Path(match.get("path") or pack_name)
-    if not target_path.is_absolute():
-        target_path = (project_dir / target_path).resolve()
-    return target_name, target_path
 
 
 def _iter_kits() -> list[tuple[str, str, Path]]:

--- a/streamtex/cli/pack_cmd.py
+++ b/streamtex/cli/pack_cmd.py
@@ -14,21 +14,13 @@ from typing import Any
 import click
 
 from . import _stx_toml
+from ._shared import _find_project_dir
 from ._toml_helpers import get_uv_sources, remove_uv_source, set_uv_source
 from .console import get_console
 
 REF_GIT_RE = re.compile(r"^git:(?P<url>[^@\s]+)(?:@(?P<rev>[^\s]+))?$")
 REF_LOCAL_RE = re.compile(r"^local:(?P<path>.+)$")
 REF_PYPI_RE = re.compile(r"^pypi:(?P<name>[A-Za-z0-9_\-]+)(?:@(?P<constraint>.+))?$")
-
-
-def _find_project_dir() -> Path:
-    cwd = Path.cwd()
-    if (cwd / "pyproject.toml").is_file():
-        return cwd
-    raise click.ClickException(
-        "No pyproject.toml in current directory. Run from a StreamTeX project root."
-    )
 
 
 def _parse_ref(ref: str) -> dict[str, Any]:

--- a/streamtex/cli/validate_cmd.py
+++ b/streamtex/cli/validate_cmd.py
@@ -14,14 +14,8 @@ from pathlib import Path
 
 import click
 
+from ._shared import _find_project_dir
 from .console import get_console
-
-
-def _find_project_dir() -> Path:
-    cwd = Path.cwd()
-    if (cwd / "pyproject.toml").is_file():
-        return cwd
-    raise click.ClickException("No pyproject.toml in current directory.")
 
 
 def _print_issues(console, label: str, issues) -> tuple[int, int]:

--- a/streamtex/core/discovery.py
+++ b/streamtex/core/discovery.py
@@ -9,7 +9,7 @@ Two layers of discovery cooperate:
   `[resolution].prefer`).
 
 The five lifecycle states (§5.6bis) — Nominal, Drift install, Indirect,
-Manifest cassé, Collision — are surfaced via the PR002/PR003/PR004 error
+Manifest broken, Collision — are surfaced via the PR002/PR003/PR004 error
 codes raised here.
 """
 

--- a/streamtex/core/validation.py
+++ b/streamtex/core/validation.py
@@ -221,6 +221,9 @@ def validate_component(mod: ModuleType) -> list[ValidationIssue]:
                     )
                     break
         except (TypeError, ValueError):
+            # inspect.signature() raises TypeError on some builtins / C-extensions
+            # and ValueError if the signature is malformed. Both are acceptable —
+            # we simply skip the CV007 keyword-only check for that callable.
             pass
 
         # CV011 — public function has its own docstring (info)

--- a/streamtex/image_editor.py
+++ b/streamtex/image_editor.py
@@ -492,10 +492,11 @@ def _load_display_from_metadata(name: str, prefix: str) -> None:
                 st.session_state.setdefault(f"{prefix}_height", meta.display_height)
             if meta.display_keep_ratio is not None:
                 st.session_state.setdefault(f"{prefix}_keep_ratio", meta.display_keep_ratio)
-        # else:
-        #     logger.warning("[DIAG:LOAD] '%s' get_current_metadata returned None — no metadata file found", name)
     except Exception:
-        # logger.warning("[DIAG:LOAD] '%s' EXCEPTION — zoom NOT loaded, flag set", name, exc_info=True)
+        # Best-effort load: if no metadata file exists yet, or it is unreadable,
+        # the image renders with its default display settings (no zoom/width
+        # restoration). Not surfaced to the user — saved settings are an
+        # enhancement, not a correctness requirement.
         pass
 
 

--- a/streamtex/styles/__init__.py
+++ b/streamtex/styles/__init__.py
@@ -25,4 +25,4 @@ from .container import (
 from .visibility import Visibility
 
 # Aggregation class and module-level aliases
-from .base import StxStyles, StreamTeX_Styles, text, container, visibility
+from .base import StxStyles, text, container, visibility

--- a/streamtex/styles/base.py
+++ b/streamtex/styles/base.py
@@ -114,7 +114,3 @@ class StxStyles:
     text_7xl   = text.sizes.idx_16   # palier 16 = 3.33 × base = 60pt @18
     text_8xl   = text.sizes.idx_17   # palier 17 = 4.00 × base = 72pt @18
     text_9xl   = text.sizes.idx_19   # palier 19 = 7.11 × base = 128pt @18
-
-
-# Backward compatibility alias (deprecated)
-StreamTeX_Styles = StxStyles

--- a/tests/test_cli_claude.py
+++ b/tests/test_cli_claude.py
@@ -1068,3 +1068,115 @@ def test_ensure_claude_gitignore_skips_commit_if_staged(tmp_path):
         cwd=str(proj), capture_output=True, text=True, timeout=10,
     )
     assert result.stdout.strip() == "init"
+
+
+# ---------------------------------------------------------------------------
+# --prune
+# ---------------------------------------------------------------------------
+
+
+def test_update_without_prune_keeps_orphan_files(tmp_path):
+    """Without --prune, files that no longer exist in the source remain."""
+    ws = _make_workspace(tmp_path)
+    target = tmp_path / "my-project"
+    target.mkdir()
+
+    install_profile(str(ws / "streamtex-claude"), "project", str(target))
+
+    # Simulate an orphan file from a previous profile version that no longer
+    # exists in the source — drop a file in the installed .claude/ tree.
+    orphan_dir = target / ".claude" / "commands" / "stx-old"
+    orphan_dir.mkdir(parents=True)
+    orphan = orphan_dir / "obsolete.md"
+    orphan.write_text("Obsolete command file\n")
+
+    runner = CliRunner()
+    os.chdir(ws)
+    result = runner.invoke(cli, ["claude", "update", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert orphan.is_file(), "Orphan should remain when --prune is not passed"
+
+
+def test_update_with_prune_removes_orphan_files(tmp_path):
+    """--prune removes installed files that no source manifest declares."""
+    ws = _make_workspace(tmp_path)
+    target = tmp_path / "my-project"
+    target.mkdir()
+
+    install_profile(str(ws / "streamtex-claude"), "project", str(target))
+
+    orphan_dir = target / ".claude" / "commands" / "stx-old"
+    orphan_dir.mkdir(parents=True)
+    orphan = orphan_dir / "obsolete.md"
+    orphan.write_text("Obsolete command file\n")
+
+    runner = CliRunner()
+    os.chdir(ws)
+    result = runner.invoke(cli, ["claude", "update", "--prune", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert "Pruned" in result.output, result.output
+    assert "obsolete.md" in result.output
+    assert not orphan.exists(), "Orphan should be removed when --prune is passed"
+
+
+def test_update_with_prune_preserves_custom_files(tmp_path):
+    """--prune must never touch .claude/custom/ — user-owned files."""
+    ws = _make_workspace(tmp_path)
+    target = tmp_path / "my-project"
+    target.mkdir()
+
+    install_profile(str(ws / "streamtex-claude"), "project", str(target))
+
+    custom_dir = target / ".claude" / "custom" / "references"
+    custom_dir.mkdir(parents=True)
+    user_file = custom_dir / "my_rules.md"
+    user_file.write_text("# My personal rules\n")
+
+    runner = CliRunner()
+    os.chdir(ws)
+    result = runner.invoke(cli, ["claude", "update", "--prune", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert user_file.is_file(), "custom/ files must survive --prune"
+
+
+def test_update_with_prune_preserves_backup_directory(tmp_path):
+    """--prune must never touch .claude/.backup/ — overwrite history."""
+    ws = _make_workspace(tmp_path)
+    target = tmp_path / "my-project"
+    target.mkdir()
+
+    install_profile(str(ws / "streamtex-claude"), "project", str(target))
+
+    backup_dir = target / ".claude" / ".backup" / "20260524-120000"
+    backup_dir.mkdir(parents=True)
+    backup_file = backup_dir / "preserved.md"
+    backup_file.write_text("Saved from a prior --force\n")
+
+    runner = CliRunner()
+    os.chdir(ws)
+    result = runner.invoke(cli, ["claude", "update", "--prune", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert backup_file.is_file(), ".backup/ files must survive --prune"
+
+
+def test_update_with_prune_preserves_stx_profile_marker(tmp_path):
+    """--prune must never touch .claude/.stx-profile."""
+    ws = _make_workspace(tmp_path)
+    target = tmp_path / "my-project"
+    target.mkdir()
+
+    install_profile(str(ws / "streamtex-claude"), "project", str(target))
+
+    marker = target / ".claude" / ".stx-profile"
+    assert marker.is_file(), "Profile marker should exist after install"
+
+    runner = CliRunner()
+    os.chdir(ws)
+    result = runner.invoke(cli, ["claude", "update", "--prune", str(target)])
+
+    assert result.exit_code == 0, result.output
+    assert marker.is_file(), ".stx-profile marker must survive --prune"

--- a/tests/test_cli_screenshot.py
+++ b/tests/test_cli_screenshot.py
@@ -1,0 +1,266 @@
+"""Tests for stx screenshot — the headless capture CLI command.
+
+The command shells out to Streamlit + Playwright at runtime, so these tests
+exercise the surface layer (CLI parsing, helper functions, early error
+handling) without actually launching a browser. Integration coverage of
+the full capture loop belongs in a slow-test marker, not here.
+"""
+
+import socket
+import sys
+from unittest.mock import patch
+
+import click
+import pytest
+from click.testing import CliRunner
+
+from streamtex.cli.commands import cli
+from streamtex.cli.screenshot_cmd import (
+    _free_port,
+    _streamlit_cmd,
+    _streamlit_importable,
+    _wait_for_http,
+    capture_screenshots,
+    screenshot,
+)
+
+# ---------------------------------------------------------------------------
+# Small utilities
+# ---------------------------------------------------------------------------
+
+
+def test_free_port_returns_valid_port():
+    """_free_port returns an int in the OS-assignable range."""
+    port = _free_port()
+    assert isinstance(port, int)
+    assert 1024 <= port <= 65535
+
+
+def test_free_port_returns_distinct_ports():
+    """Two consecutive calls should normally return different ports."""
+    p1 = _free_port()
+    p2 = _free_port()
+    # Both must be valid; equality is technically possible but extremely rare.
+    assert isinstance(p1, int) and isinstance(p2, int)
+
+
+def test_wait_for_http_raises_on_unreachable():
+    """An unreachable URL hits the timeout and raises TimeoutError."""
+    # Bind a socket to a random port then immediately close it, so the URL
+    # is guaranteed unreachable for the rest of the test.
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+    with pytest.raises(TimeoutError):
+        _wait_for_http(f"http://127.0.0.1:{port}/", timeout_s=0.5)
+
+
+def test_streamlit_importable_returns_bool():
+    """_streamlit_importable returns a real bool (depends on test env)."""
+    result = _streamlit_importable()
+    assert isinstance(result, bool)
+
+
+# ---------------------------------------------------------------------------
+# Subprocess command construction
+# ---------------------------------------------------------------------------
+
+
+def test_streamlit_cmd_prefers_current_interpreter_when_importable():
+    """When streamlit is importable in the running interpreter, use sys.executable -m streamlit."""
+    with patch("streamtex.cli.screenshot_cmd._streamlit_importable", return_value=True):
+        cmd = _streamlit_cmd("book.py", 8501)
+    assert cmd[0] == sys.executable
+    assert cmd[1:3] == ["-m", "streamlit"]
+    assert "run" in cmd
+    assert "book.py" in cmd
+    assert "8501" in cmd
+    assert "--server.headless" in cmd
+
+
+def test_streamlit_cmd_falls_back_to_uv_when_not_importable():
+    """When streamlit isn't importable, the command should attempt `uv run streamlit`."""
+    with (
+        patch("streamtex.cli.screenshot_cmd._streamlit_importable", return_value=False),
+        patch("shutil.which", return_value="/usr/local/bin/uv"),
+    ):
+        cmd = _streamlit_cmd("book.py", 8501)
+    assert cmd[0] == "/usr/local/bin/uv"
+    assert cmd[1:3] == ["run", "streamlit"]
+    assert "book.py" in cmd
+    assert "8501" in cmd
+
+
+def test_streamlit_cmd_final_fallback_when_uv_missing():
+    """If neither streamlit importable nor uv on PATH, fall back to sys.executable."""
+    with (
+        patch("streamtex.cli.screenshot_cmd._streamlit_importable", return_value=False),
+        patch("shutil.which", return_value=None),
+    ):
+        cmd = _streamlit_cmd("book.py", 8501)
+    assert cmd[0] == sys.executable
+    assert cmd[1:3] == ["-m", "streamlit"]
+
+
+def test_streamlit_cmd_includes_required_flags():
+    """All required Streamlit headless flags are present."""
+    with patch("streamtex.cli.screenshot_cmd._streamlit_importable", return_value=True):
+        cmd = _streamlit_cmd("project/book.py", 9001)
+    assert "--server.headless" in cmd and "true" in cmd
+    assert "--server.runOnSave" in cmd and "false" in cmd
+    assert "--browser.gatherUsageStats" in cmd and "false" in cmd
+    assert "--server.port" in cmd and "9001" in cmd
+
+
+# ---------------------------------------------------------------------------
+# capture_screenshots — early validation
+# ---------------------------------------------------------------------------
+
+
+def test_capture_screenshots_raises_on_missing_book(tmp_path):
+    """A non-existent book path raises ClickException before any subprocess starts."""
+    missing = tmp_path / "does_not_exist.py"
+    with pytest.raises(click.ClickException) as exc_info:
+        capture_screenshots(book=str(missing), out_dir=str(tmp_path / "out"))
+    assert "File not found" in str(exc_info.value.message)
+
+
+def test_capture_screenshots_raises_when_playwright_missing(tmp_path, monkeypatch):
+    """A missing Playwright install surfaces the install-hint ClickException."""
+    book = tmp_path / "book.py"
+    book.write_text("# minimal", encoding="utf-8")
+
+    # Force the playwright import inside capture_screenshots to fail.
+    real_import = __import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "playwright.sync_api" or name.startswith("playwright"):
+            raise ImportError("forced for test")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr("builtins.__import__", fake_import)
+
+    with pytest.raises(click.ClickException) as exc_info:
+        capture_screenshots(book=str(book), out_dir=str(tmp_path / "out"))
+    # Hint mentions the extras group and the playwright install command.
+    msg = str(exc_info.value.message)
+    assert "streamtex[pdf]" in msg
+    assert "playwright install" in msg
+
+
+# ---------------------------------------------------------------------------
+# CLI surface — argument parsing + help
+# ---------------------------------------------------------------------------
+
+
+def test_cli_screenshot_help_renders():
+    """`stx screenshot --help` lists all 5 options."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["screenshot", "--help"])
+    assert result.exit_code == 0
+    for flag in ["--out", "--viewport", "--no-per-slide", "--no-full-page", "--settle"]:
+        assert flag in result.output
+
+
+def test_cli_screenshot_rejects_malformed_viewport(tmp_path):
+    """A --viewport without 'WxH' shape is rejected before any capture call."""
+    runner = CliRunner()
+    book = tmp_path / "book.py"
+    book.write_text("# minimal", encoding="utf-8")
+    result = runner.invoke(
+        cli,
+        ["screenshot", str(book), "--viewport", "not-a-viewport"],
+    )
+    assert result.exit_code != 0
+    assert "Invalid --viewport" in result.output
+
+
+def test_cli_screenshot_rejects_missing_book():
+    """An invocation pointing at a missing book.py surfaces the ClickException."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["screenshot", "/tmp/never_exists_streamtex_test.py"])
+    assert result.exit_code != 0
+    assert "File not found" in result.output
+
+
+def test_cli_screenshot_parses_viewport_into_tuple(tmp_path, monkeypatch):
+    """Valid --viewport WxH is split into an (int, int) tuple before delegation."""
+    book = tmp_path / "book.py"
+    book.write_text("# minimal", encoding="utf-8")
+
+    captured = {}
+
+    def fake_capture(**kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr(
+        "streamtex.cli.screenshot_cmd.capture_screenshots", fake_capture
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["screenshot", str(book), "--viewport", "1280x720"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured.get("viewport") == (1280, 720)
+
+
+def test_cli_screenshot_no_flags_invert_defaults(tmp_path, monkeypatch):
+    """--no-per-slide and --no-full-page each invert the corresponding default."""
+    book = tmp_path / "book.py"
+    book.write_text("# minimal", encoding="utf-8")
+
+    captured = {}
+    monkeypatch.setattr(
+        "streamtex.cli.screenshot_cmd.capture_screenshots",
+        lambda **kw: captured.update(kw),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli,
+        ["screenshot", str(book), "--no-per-slide", "--no-full-page"],
+    )
+    assert result.exit_code == 0, result.output
+    assert captured.get("per_slide") is False
+    assert captured.get("full_page") is False
+
+
+def test_cli_screenshot_passes_settle_value(tmp_path, monkeypatch):
+    """--settle is forwarded as settle_s (float)."""
+    book = tmp_path / "book.py"
+    book.write_text("# minimal", encoding="utf-8")
+
+    captured = {}
+    monkeypatch.setattr(
+        "streamtex.cli.screenshot_cmd.capture_screenshots",
+        lambda **kw: captured.update(kw),
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(
+        cli, ["screenshot", str(book), "--settle", "1.5"]
+    )
+    assert result.exit_code == 0, result.output
+    assert captured.get("settle_s") == 1.5
+
+
+# ---------------------------------------------------------------------------
+# Command registration
+# ---------------------------------------------------------------------------
+
+
+def test_screenshot_is_registered_on_cli():
+    """The `screenshot` command is part of the top-level `stx` CLI."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "screenshot" in result.output
+
+
+def test_screenshot_command_object_has_expected_options():
+    """Direct introspection: every documented option is on the Click command."""
+    declared = {opt.name for opt in screenshot.params}
+    expected = {"book", "out_dir", "viewport", "no_per_slide", "no_full_page", "settle"}
+    assert expected.issubset(declared)


### PR DESCRIPTION
Output of the 2026-05-23 coherence-audit cycle for the **streamtex** library.

## Commits (6)

- **`chore(library): fix French docstring residue + add missing --granularity help`** — `discovery.py:12` "Manifest cassé" → "Manifest broken" (matches the same module's English error string at line 238); adds the lone missing `help=` text to `--granularity` in `component_cmd.py`. (Audit Checks 10, 42)
- **`refactor(styles): remove deprecated StreamTeX_Styles alias`** — drops the self-described "Backward compatibility alias (deprecated)" from `__init__.py`, `styles/__init__.py`, and `styles/base.py`. Zero external usages. 40 style tests pass. (Audit Check 35)
- **`chore(library): clarify 3 silent exception handlers`** — removes dead commented-out logger lines from `image_editor.py:497`; adds short explanatory comments to two unexplained `except` blocks (`book.py:347`, `core/validation.py:223`). No behaviour change. (Audit Check 38)
- **`refactor(cli): deduplicate _find_project_dir + _resolve_local_pack_dir into _shared.py`** — 6 copies of `_find_project_dir` and 2 copies of `_resolve_local_pack_dir` consolidated into new `streamtex/cli/_shared.py`. Net -57 duplicated lines, +65 centralized. Canonical error message standardized. 528 CLI tests pass. (Audit Check 33)
- **`test(cli): add tests for stx screenshot command (Check 12d)`** — 18 tests for `cli/screenshot_cmd.py` (added in 0.7.8, previously untested). Covers helper utilities, command construction (3 branches), early validation, and the CLI surface. No real browser/Streamlit launched. (Audit Check 12)
- **`feat(cli): add --prune flag to stx claude update`** — new opt-in flag removes orphan files in installed `.claude/` that no manifest declares anymore. Protects `custom/`, `.backup/`, and `.stx-profile`. 5 new tests. (Audit Item #4 follow-up)

## Audit progress

This is part of a coordinated cycle across the 3 repos. Started with 14 audit errors / 186 warnings; this PR + the companion PRs in streamtex-docs and streamtex-claude bring it to **0 errors / ~75 low-priority warnings**.

## Notes

- The `--prune` feature is additive (default behaviour unchanged). Suggest bumping streamtex from 0.7.13 → 0.7.14 (patch) when releasing.
- Full test suite passes locally: **2177 tests passed, 1 skipped**.
- Ruff clean across all touched files.