### PR TITLE
feat(artifacts): generic engine + 8 extended categories (manifest 0.2)

### DIFF
--- a/streamtex/cli/artifact_cmd.py
+++ b/streamtex/cli/artifact_cmd.py
@@ -10,15 +10,19 @@ See `streamtex.core.artifacts` for the engine API and the RFC at
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import click
 
 from streamtex.core.artifacts import (
     ArtifactKind,
     discover_artifacts,
+    install_claude_artifact,
     resolve_artifact,
     validate_artifact,
 )
 
+from ._shared import _find_project_dir
 from .console import get_console
 
 _KIND_CHOICES = [k.value for k in ArtifactKind]
@@ -101,6 +105,12 @@ def show_cmd(name: str, kind_str: str, pack_filter: str | None) -> None:
         _render_palette(discovered, console)
     elif kind == ArtifactKind.AI_PROMPT:
         _render_ai_prompt(discovered, console)
+    elif kind == ArtifactKind.ARCHETYPE:
+        _render_archetype(discovered, console)
+    elif kind == ArtifactKind.GUIDELINE:
+        _render_guideline(discovered, console)
+    elif kind in (ArtifactKind.SKILL, ArtifactKind.AGENT):
+        _render_skill_or_agent(discovered, console, kind)
     else:
         # Fallback: dump path + first lines for categories not yet rendered.
         try:
@@ -159,6 +169,71 @@ def validate_cmd(name: str | None, kind_str: str | None, pack_filter: str | None
         )
 
 
+@artifact.command("install")
+@click.argument("name")
+@click.option(
+    "--kind",
+    "kind_str",
+    type=click.Choice(["skill", "agent"]),
+    required=True,
+    help="Only skills and agents are installable to .claude/custom/.",
+)
+@click.option("--pack", "pack_filter", default=None, help="Disambiguate by pack name.")
+@click.option("--yes", "auto_yes", is_flag=True, help="Skip confirmation prompt.")
+@click.option(
+    "--overwrite", is_flag=True, help="Overwrite an existing installed file."
+)
+def install_cmd(
+    name: str,
+    kind_str: str,
+    pack_filter: str | None,
+    auto_yes: bool,
+    overwrite: bool,
+) -> None:
+    """Install a pack-shipped skill or agent into .claude/custom/.
+
+    Lifecycle decision EAR-4: confirmation by default, ``--yes`` to skip.
+    Files are namespaced as ``<pack_slug>__<name>.md`` to avoid collisions.
+    """
+    console = get_console()
+    kind = ArtifactKind(kind_str)
+    try:
+        discovered = resolve_artifact(
+            name, kind, prefer=[pack_filter] if pack_filter else None
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    project_dir = _find_project_dir() or Path.cwd()
+    target_dir = project_dir / ".claude" / "custom" / (
+        "skills" if kind == ArtifactKind.SKILL else "agents"
+    )
+    pack_slug = discovered.pack.replace("streamtex-pack-", "").replace("-", "_")
+    target = target_dir / f"{pack_slug}__{discovered.name}.md"
+
+    console.print(
+        f"Install {discovered.pack}:{discovered.name} ({kind.value}) "
+        f"\n  from: {discovered.path}"
+        f"\n  to:   {target}"
+    )
+
+    if not auto_yes:
+        if not click.confirm("Proceed?", default=True):
+            console.print("[yellow]Cancelled.[/yellow]")
+            return
+
+    report = install_claude_artifact(
+        name, kind, project_dir, pack=pack_filter, overwrite=overwrite
+    )
+    if report.action == "skipped":
+        console.print(
+            "[yellow]Skipped[/yellow] — destination already exists. Use "
+            "--overwrite to replace."
+        )
+    else:
+        console.print(f"[green]{report.action}[/green] → {report.destination}")
+
+
 # ---------------------------------------------------------------------------
 # Per-kind renderers
 # ---------------------------------------------------------------------------
@@ -192,3 +267,57 @@ def _render_ai_prompt(discovered, console) -> None:
         console.print(f"[bold]suffix-{orient}[/bold]:")
         console.print(prompt.suffixes[orient])
         console.print()
+
+
+def _render_archetype(discovered, console) -> None:
+    from streamtex.core.artifacts.archetype import load_archetype_from_path
+
+    arch = load_archetype_from_path(discovered.path, pack=discovered.pack)
+    console.print(f"description: {arch.description}")
+    console.print(
+        f"orientation: {arch.orientation}  •  status: {arch.status}  •  since: {arch.since}"
+    )
+    if arch.tags:
+        console.print(f"tags: {', '.join(arch.tags)}")
+    if arch.palette_refs:
+        console.print(f"palette refs: {', '.join(arch.palette_refs)}")
+    console.print(f"extrapolable: {arch.extrapolable}")
+    console.print()
+    body = arch.body.lstrip()
+    console.print(body[:1500])
+    if len(body) > 1500:
+        console.print("[dim]… (truncated)[/dim]")
+
+
+def _render_guideline(discovered, console) -> None:
+    from streamtex.core.artifacts.guideline import load_guideline_from_path
+
+    gl = load_guideline_from_path(discovered.path, pack=discovered.pack)
+    console.print(f"description: {gl.description}")
+    console.print(f"since: {gl.since}")
+    if gl.rules:
+        console.print(f"rules: {', '.join(gl.rules)}")
+    if gl.applies_to:
+        console.print(f"applies to: {', '.join(gl.applies_to)}")
+    console.print()
+    body = gl.body.lstrip()
+    console.print(body[:1500])
+    if len(body) > 1500:
+        console.print("[dim]… (truncated)[/dim]")
+
+
+def _render_skill_or_agent(discovered, console, kind: ArtifactKind) -> None:
+    if kind == ArtifactKind.SKILL:
+        from streamtex.core.artifacts.skill import load_skill_from_path
+        loaded = load_skill_from_path(discovered.path, pack=discovered.pack)
+    else:
+        from streamtex.core.artifacts.agent import load_agent_from_path
+        loaded = load_agent_from_path(discovered.path, pack=discovered.pack)
+    console.print(f"description: {loaded.description}")
+    console.print(f"namespace: {loaded.namespaced_name}")
+    console.print(f"install filename: {loaded.install_filename}")
+    console.print()
+    body = loaded.body.lstrip()
+    console.print(body[:1500])
+    if len(body) > 1500:
+        console.print("[dim]… (truncated)[/dim]")

--- a/streamtex/cli/artifact_cmd.py
+++ b/streamtex/cli/artifact_cmd.py
@@ -1,0 +1,194 @@
+"""stx artifact — list / show / validate for the generic artifact engine.
+
+A single uniform CLI for all manifest-0.2 artifact categories (palette,
+ai_prompt, archetype, guideline, skill, agent, asset, integration). Per-kind
+formatting lives in the per-category render helpers below.
+
+See `streamtex.core.artifacts` for the engine API and the RFC at
+`documentation/maintenance/design-packs/RFC-extended-artifacts.md`.
+"""
+
+from __future__ import annotations
+
+import click
+
+from streamtex.core.artifacts import (
+    ArtifactKind,
+    discover_artifacts,
+    resolve_artifact,
+    validate_artifact,
+)
+
+from .console import get_console
+
+_KIND_CHOICES = [k.value for k in ArtifactKind]
+
+
+def _parse_kind(value: str | None) -> ArtifactKind | None:
+    if value is None:
+        return None
+    try:
+        return ArtifactKind(value)
+    except ValueError as exc:
+        raise click.BadParameter(
+            f"unknown artifact kind {value!r} ; supported: {', '.join(_KIND_CHOICES)}"
+        ) from exc
+
+
+def _kinds_to_scan(kind: ArtifactKind | None) -> list[ArtifactKind]:
+    return [kind] if kind else list(ArtifactKind)
+
+
+@click.group()
+def artifact() -> None:
+    """Manage extended pack artifacts (manifest 0.2 — palettes, prompts, …)."""
+
+
+@artifact.command("list")
+@click.option(
+    "--kind",
+    "kind_str",
+    type=click.Choice(_KIND_CHOICES),
+    default=None,
+    help="Filter by artifact category. Default: all categories.",
+)
+@click.option("--pack", "pack_filter", default=None, help="Filter by pack name.")
+def list_cmd(kind_str: str | None, pack_filter: str | None) -> None:
+    """Enumerate artifacts across installed packs."""
+    console = get_console()
+    kind = _parse_kind(kind_str)
+    total = 0
+    for k in _kinds_to_scan(kind):
+        found = discover_artifacts(k, pack=pack_filter)
+        if not found:
+            continue
+        total += len(found)
+        console.print(f"[bold]{k.value}[/bold] ({len(found)})")
+        for art in found:
+            console.print(f"  {art.pack}:{art.name}  [dim]({art.path})[/dim]")
+    if total == 0:
+        scope = f"kind={kind.value}" if kind else "any kind"
+        pack_scope = f" pack={pack_filter}" if pack_filter else ""
+        console.print(f"[dim]No artifacts found ({scope}{pack_scope}).[/dim]")
+
+
+@artifact.command("show")
+@click.argument("name")
+@click.option(
+    "--kind",
+    "kind_str",
+    type=click.Choice(_KIND_CHOICES),
+    required=True,
+    help="Artifact category.",
+)
+@click.option("--pack", "pack_filter", default=None, help="Disambiguate by pack name.")
+def show_cmd(name: str, kind_str: str, pack_filter: str | None) -> None:
+    """Show one artifact's content (formatted per kind)."""
+    console = get_console()
+    kind = ArtifactKind(kind_str)
+    try:
+        discovered = resolve_artifact(
+            name, kind, prefer=[pack_filter] if pack_filter else None
+        )
+    except Exception as exc:
+        raise click.ClickException(str(exc)) from exc
+
+    console.print(f"[bold]{discovered.pack}:{discovered.name}[/bold]  ({kind.value})")
+    console.print(f"[dim]{discovered.path}[/dim]")
+    console.print()
+
+    if kind == ArtifactKind.PALETTE:
+        _render_palette(discovered, console)
+    elif kind == ArtifactKind.AI_PROMPT:
+        _render_ai_prompt(discovered, console)
+    else:
+        # Fallback: dump path + first lines for categories not yet rendered.
+        try:
+            if discovered.path.is_file():
+                console.print(discovered.path.read_text()[:2000])
+            else:
+                for child in sorted(discovered.path.iterdir())[:20]:
+                    console.print(f"  {child.name}")
+        except Exception as exc:
+            console.print(f"[red]Could not preview: {exc}[/red]")
+
+
+@artifact.command("validate")
+@click.argument("name", required=False)
+@click.option(
+    "--kind",
+    "kind_str",
+    type=click.Choice(_KIND_CHOICES),
+    default=None,
+    help="Filter by artifact category. Default: all categories.",
+)
+@click.option("--pack", "pack_filter", default=None, help="Filter by pack name.")
+def validate_cmd(name: str | None, kind_str: str | None, pack_filter: str | None) -> None:
+    """Validate one (NAME + --kind) or all matching artifacts.
+
+    Exit code 0 if no errors ; 1 otherwise.
+    """
+    console = get_console()
+    kind = _parse_kind(kind_str)
+    targets = []
+    for k in _kinds_to_scan(kind):
+        for art in discover_artifacts(k, pack=pack_filter):
+            if name is None or art.name == name:
+                targets.append((k, art))
+
+    if not targets:
+        console.print("[yellow]No artifacts matched the filters.[/yellow]")
+        return
+
+    total_errors = 0
+    for k, art in targets:
+        issues = validate_artifact(art.path, k)
+        errors = [i for i in issues if i.is_error()]
+        warnings = [i for i in issues if i.severity == "warning"]
+        status = "[green]OK[/green]" if not errors else f"[red]{len(errors)} error(s)[/red]"
+        warn_tag = f" [yellow]({len(warnings)} warn)[/yellow]" if warnings else ""
+        console.print(f"{art.pack}:{art.name}  ({k.value})  {status}{warn_tag}")
+        for issue in errors + warnings:
+            tag_color = "red" if issue.severity == "error" else "yellow"
+            console.print(f"  [{tag_color}][{issue.code}][/{tag_color}] {issue.message}")
+        total_errors += len(errors)
+
+    if total_errors:
+        raise click.ClickException(
+            f"{total_errors} validation error(s) across {len(targets)} artifact(s)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-kind renderers
+# ---------------------------------------------------------------------------
+
+
+def _render_palette(discovered, console) -> None:
+    from streamtex.core.artifacts.palette import load_palette_from_path
+
+    palette = load_palette_from_path(discovered.path, pack=discovered.pack)
+    console.print(f"version: {palette.version}")
+    console.print(f"colors ({len(palette.colors)}):")
+    for token, color in palette.colors.items():
+        role = f" — {color.role}" if color.role else ""
+        console.print(f"  {token:<16}  {color.hex}{role}")
+    if palette.dimensions:
+        console.print(f"dimensions ({len(palette.dimensions)}):")
+        for dim, target in palette.dimensions.items():
+            console.print(f"  {dim:<16} → {target}")
+
+
+def _render_ai_prompt(discovered, console) -> None:
+    from streamtex.core.artifacts.ai_prompt import load_ai_prompt_from_path
+
+    prompt = load_ai_prompt_from_path(discovered.path, pack=discovered.pack)
+    console.print(f"orientations: {', '.join(sorted(prompt.suffixes)) or '(none)'}")
+    console.print()
+    console.print("[bold]prefix[/bold]:")
+    console.print(prompt.prefix)
+    console.print()
+    for orient in sorted(prompt.suffixes):
+        console.print(f"[bold]suffix-{orient}[/bold]:")
+        console.print(prompt.suffixes[orient])
+        console.print()

--- a/streamtex/cli/commands.py
+++ b/streamtex/cli/commands.py
@@ -6,6 +6,7 @@ import click
 
 __version__ = version("streamtex")
 
+from .artifact_cmd import artifact as artifact_group
 from .bib_cmd import generate_stubs
 from .cache_cmd import warmup as cache_warmup
 from .claude_cmd import check_cmd as claude_check
@@ -196,6 +197,7 @@ cli.add_command(pack_group, name="pack")
 cli.add_command(component_group, name="component")
 cli.add_command(ds_group, name="ds")
 cli.add_command(kit_group, name="kit")
+cli.add_command(artifact_group, name="artifact")
 cli.add_command(stx_validate, name="validate")
 
 

--- a/streamtex/core/__init__.py
+++ b/streamtex/core/__init__.py
@@ -16,6 +16,6 @@ remaining infrastructure stays under `streamtex.core.*` per the convention in
 §5.0 of the plan.
 """
 
-from streamtex.core import contracts, validation, discovery
+from streamtex.core import artifacts, contracts, discovery, validation
 
-__all__ = ["contracts", "validation", "discovery"]
+__all__ = ["artifacts", "contracts", "validation", "discovery"]

--- a/streamtex/core/artifacts/__init__.py
+++ b/streamtex/core/artifacts/__init__.py
@@ -1,0 +1,49 @@
+"""Generic artifact engine for StreamTeX packs (manifest format 0.2+).
+
+A pack can ship multiple categories of reusable artifacts: data-first (palettes,
+AI prompts), structured documentation (archetypes, guidelines), Claude Code
+assets (skills, agents), binary resources (assets), and integration recipes for
+third-party frameworks.
+
+This module provides the **one** generic engine that all categories share:
+
+* `ArtifactKind` — enum of supported categories.
+* `DiscoveredArtifact` — uniform record returned by discovery.
+* `discover_artifacts(kind, *, pack=None)` — enumerate across the installed
+  pack ecosystem.
+* `resolve_artifact(name, kind, *, prefer=None)` — pick one in case of
+  cross-pack collision.
+* `validate_artifact(path, kind)` — return ValidationIssue list for a single
+  artifact file/dir.
+* `load_artifact(name, kind, *, pack=None)` — return the typed Python view
+  of an artifact (dispatches on kind).
+
+Per-category contracts (TypedDict + validator + loader) live in sibling
+modules: `palette.py`, `ai_prompt.py`, `archetype.py`, `guideline.py`,
+`skill.py`, `agent.py`, `asset.py`, `integration.py`.
+
+The engine is **additive** on top of the format-0.1 mechanism: packs without
+a `[pack.data]` section in their manifest are unaffected.
+"""
+
+from streamtex.core.artifacts.spec import (
+    ArtifactKind,
+    ArtifactSpec,
+    DiscoveredArtifact,
+)
+from streamtex.core.artifacts.discovery import (
+    discover_artifacts,
+    resolve_artifact,
+)
+from streamtex.core.artifacts.validation import validate_artifact
+from streamtex.core.artifacts.loaders import load_artifact
+
+__all__ = [
+    "ArtifactKind",
+    "ArtifactSpec",
+    "DiscoveredArtifact",
+    "discover_artifacts",
+    "resolve_artifact",
+    "validate_artifact",
+    "load_artifact",
+]

--- a/streamtex/core/artifacts/__init__.py
+++ b/streamtex/core/artifacts/__init__.py
@@ -37,13 +37,23 @@ from streamtex.core.artifacts.discovery import (
 )
 from streamtex.core.artifacts.validation import validate_artifact
 from streamtex.core.artifacts.loaders import load_artifact
+from streamtex.core.artifacts.install import (
+    InstallReport,
+    install_claude_artifact,
+    list_claude_artifacts_for_pack,
+    uninstall_claude_artifact,
+)
 
 __all__ = [
     "ArtifactKind",
     "ArtifactSpec",
     "DiscoveredArtifact",
+    "InstallReport",
     "discover_artifacts",
     "resolve_artifact",
     "validate_artifact",
     "load_artifact",
+    "install_claude_artifact",
+    "list_claude_artifacts_for_pack",
+    "uninstall_claude_artifact",
 ]

--- a/streamtex/core/artifacts/_frontmatter.py
+++ b/streamtex/core/artifacts/_frontmatter.py
@@ -1,0 +1,95 @@
+"""Minimal YAML frontmatter parser shared by archetype/guideline/skill/agent.
+
+Supports the standard convention: a file starting with `---` opens a YAML block
+that ends at the next `---` line. We parse a deliberately tiny subset of YAML
+(scalars, inline lists, multi-line lists) to avoid pulling in PyYAML as a
+runtime dependency of streamtex core.
+
+For richer frontmatter needs (anchors, references, multi-line strings beyond
+inline), packs may use full YAML — they just need PyYAML installed and parse
+manually before calling our validators.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+_FRONTMATTER_RE = re.compile(
+    r"^---\s*\n(?P<fm>.*?)\n---\s*\n(?P<body>.*)$",
+    re.DOTALL,
+)
+
+
+def split_frontmatter(text: str) -> tuple[dict[str, Any], str]:
+    """Split a markdown file into (frontmatter dict, body text).
+
+    If no frontmatter block is found, returns ({}, original_text).
+    """
+    m = _FRONTMATTER_RE.match(text)
+    if not m:
+        return {}, text
+    fm = _parse_simple_yaml(m.group("fm"))
+    return fm, m.group("body")
+
+
+def _parse_simple_yaml(text: str) -> dict[str, Any]:
+    """Parse a tiny YAML subset (scalars + inline lists + indented lists)."""
+    out: dict[str, Any] = {}
+    lines = text.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if not line.strip() or line.lstrip().startswith("#"):
+            i += 1
+            continue
+        if ":" not in line:
+            i += 1
+            continue
+        key, _, raw_value = line.partition(":")
+        key = key.strip()
+        raw_value = raw_value.strip()
+        if raw_value == "":
+            # Multi-line list: collect "- item" lines that follow
+            collected: list[str] = []
+            j = i + 1
+            while j < len(lines) and (lines[j].startswith("  ") or lines[j].strip().startswith("-")):
+                stripped = lines[j].strip()
+                if stripped.startswith("-"):
+                    collected.append(_coerce(stripped[1:].strip()))
+                j += 1
+            if collected:
+                out[key] = collected
+            i = j
+            continue
+        if raw_value.startswith("[") and raw_value.endswith("]"):
+            inner = raw_value[1:-1].strip()
+            if inner:
+                out[key] = [_coerce(p.strip()) for p in inner.split(",")]
+            else:
+                out[key] = []
+        else:
+            out[key] = _coerce(raw_value)
+        i += 1
+    return out
+
+
+def _coerce(value: str) -> Any:
+    """Coerce a scalar string into bool/int/None/str."""
+    if (value.startswith('"') and value.endswith('"')) or (
+        value.startswith("'") and value.endswith("'")
+    ):
+        return value[1:-1]
+    lowered = value.lower()
+    if lowered == "true":
+        return True
+    if lowered == "false":
+        return False
+    if lowered in ("null", "none", "~", ""):
+        return None
+    if value.lstrip("-").isdigit():
+        try:
+            return int(value)
+        except ValueError:
+            pass
+    return value

--- a/streamtex/core/artifacts/agent.py
+++ b/streamtex/core/artifacts/agent.py
@@ -1,0 +1,101 @@
+"""Agent artifact — Claude Code agent definition, pack-scoped.
+
+Same shape as a skill: markdown with Claude Code frontmatter. The semantic
+difference is purely consumer-side — Claude Code interprets agents and
+skills differently. From the pack's point of view, both are pack-scoped
+markdown blobs with ``name`` + ``description``.
+
+Filesystem convention: ``<pack>/agents/<name>.md``
+
+Validation codes: AGV001-AGV010 (agent validation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from streamtex.core.artifacts._frontmatter import split_frontmatter
+from streamtex.core.validation import ValidationIssue
+
+_REQUIRED_FIELDS = ("name", "description")
+
+
+@dataclass(frozen=True)
+class Agent:
+    """Typed view of a Claude Code agent artifact."""
+
+    name: str
+    pack: str
+    description: str
+    body: str
+
+    @property
+    def namespaced_name(self) -> str:
+        return f"{self.pack}:{self.name}"
+
+    @property
+    def install_filename(self) -> str:
+        pack_slug = self.pack.replace("streamtex-pack-", "").replace("-", "_")
+        return f"{pack_slug}__{self.name}.md"
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_agent(path: Path) -> list[ValidationIssue]:
+    """Run validation checks on a single agent markdown file.
+
+    AGV001 — file readable
+    AGV002 — has YAML frontmatter
+    AGV003 — required fields present
+    AGV004 — body is non-trivial (≥ 100 chars)
+    """
+    issues: list[ValidationIssue] = []
+    if not path.exists() or not path.is_file():
+        return [_issue("AGV001", "error", path, "agent file not found")]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return [_issue("AGV001", "error", path, f"unreadable: {exc}")]
+
+    if not text.startswith("---"):
+        issues.append(_issue("AGV002", "error", path, "missing YAML frontmatter"))
+        return issues
+
+    fm, body = split_frontmatter(text)
+    for key in _REQUIRED_FIELDS:
+        if key not in fm or fm[key] in (None, ""):
+            issues.append(_issue("AGV003", "error", path, f"missing required field '{key}'"))
+
+    if len(body.strip()) < 100:
+        issues.append(_issue("AGV004", "warning", path, "agent body suspiciously short (< 100 chars)"))
+
+    return issues
+
+
+def load_agent_from_path(path: Path, *, pack: str = "") -> Agent:
+    """Parse an agent markdown file into a typed `Agent` dataclass."""
+    issues = validate_agent(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid agent at {path}:\n{joined}")
+
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    return Agent(
+        name=str(fm.get("name") or path.stem),
+        pack=pack,
+        description=str(fm.get("description") or ""),
+        body=body,
+    )
+
+
+def load_agent(name: str, *, pack: str | None = None) -> Agent:
+    """Convenience: resolve + load an agent by name."""
+    from streamtex.core.artifacts.loaders import load_artifact
+    from streamtex.core.artifacts.spec import ArtifactKind
+
+    return load_artifact(name, ArtifactKind.AGENT, pack=pack)

--- a/streamtex/core/artifacts/ai_prompt.py
+++ b/streamtex/core/artifacts/ai_prompt.py
@@ -1,0 +1,163 @@
+"""AI prompt artifact — prefix + per-orientation suffixes as plain text.
+
+An AI prompt lives at `<pack>/ai_prompts/<name>/`:
+
+    ai_prompts/
+    └── scene_generation/
+        ├── prefix.txt              (required)
+        ├── suffix-landscape.txt    (≥ 1 required across landscape/portrait/square)
+        ├── suffix-portrait.txt
+        └── suffix-square.txt
+
+The Python view (`AIPrompt`) exposes:
+
+* `prefix: str` — the canonical context paragraph.
+* `suffixes: dict[str, str]` — keyed by orientation ("landscape", "portrait",
+  "square"). At least one key is guaranteed by validation.
+
+Validation codes: APV001–APV010 (`AI prompt validation`).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from streamtex.core.validation import ValidationIssue
+
+_SUPPORTED_ORIENTATIONS: tuple[str, ...] = ("landscape", "portrait", "square")
+_SUFFIX_RE = re.compile(r"^suffix-(?P<orient>[a-z]+)\.txt$")
+
+
+@dataclass(frozen=True)
+class AIPrompt:
+    """Typed view of an AI prompt artifact."""
+
+    name: str
+    pack: str
+    prefix: str
+    suffixes: dict[str, str] = field(default_factory=dict)
+
+    def compose(self, *, orientation: str = "landscape", scene: str = "") -> str:
+        """Assemble a complete prompt: prefix + scene + suffix(orientation)."""
+        if orientation not in self.suffixes:
+            available = ", ".join(sorted(self.suffixes)) or "(none)"
+            raise KeyError(
+                f"AI prompt {self.pack}:{self.name}: orientation "
+                f"{orientation!r} not declared. Available: {available}"
+            )
+        parts = [self.prefix.strip()]
+        if scene:
+            parts.append(scene.strip())
+        parts.append(self.suffixes[orientation].strip())
+        return "\n\n".join(parts)
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_ai_prompt(path: Path) -> list[ValidationIssue]:
+    """Run validation checks on a single AI prompt directory.
+
+    APV001 — directory exists
+    APV002 — `prefix.txt` present and non-empty
+    APV003 — at least one `suffix-<orientation>.txt` present
+    APV004 — every suffix orientation is in the supported set
+    APV005 — no empty suffix file
+    APV006 — no unknown files at the artifact root (warning)
+    """
+    issues: list[ValidationIssue] = []
+    if not path.exists() or not path.is_dir():
+        return [_issue("APV001", "error", path, "AI prompt directory not found")]
+
+    prefix_path = path / "prefix.txt"
+    if not prefix_path.exists() or not prefix_path.is_file():
+        issues.append(_issue("APV002", "error", path, "prefix.txt is required"))
+    else:
+        try:
+            content = prefix_path.read_text(encoding="utf-8").strip()
+            if not content:
+                issues.append(_issue("APV002", "error", prefix_path, "prefix.txt is empty"))
+        except Exception as exc:
+            issues.append(_issue("APV002", "error", prefix_path, f"unreadable: {exc}"))
+
+    found_orientations: list[str] = []
+    for child in sorted(path.iterdir()):
+        if child.name == "prefix.txt":
+            continue
+        m = _SUFFIX_RE.match(child.name)
+        if m:
+            orient = m.group("orient")
+            if orient not in _SUPPORTED_ORIENTATIONS:
+                issues.append(
+                    _issue(
+                        "APV004",
+                        "error",
+                        child,
+                        f"unsupported orientation {orient!r}; supported: "
+                        f"{', '.join(_SUPPORTED_ORIENTATIONS)}",
+                    )
+                )
+                continue
+            found_orientations.append(orient)
+            try:
+                if not child.read_text(encoding="utf-8").strip():
+                    issues.append(_issue("APV005", "error", child, "suffix file is empty"))
+            except Exception as exc:
+                issues.append(_issue("APV005", "error", child, f"unreadable: {exc}"))
+        else:
+            issues.append(
+                _issue(
+                    "APV006",
+                    "warning",
+                    child,
+                    f"unexpected file {child.name!r} in AI prompt directory",
+                )
+            )
+
+    if not found_orientations:
+        issues.append(
+            _issue(
+                "APV003",
+                "error",
+                path,
+                "at least one suffix-<orientation>.txt is required "
+                f"({', '.join(_SUPPORTED_ORIENTATIONS)})",
+            )
+        )
+
+    return issues
+
+
+def load_ai_prompt_from_path(path: Path, *, pack: str = "") -> AIPrompt:
+    """Parse an AI prompt directory into a typed `AIPrompt` dataclass.
+
+    Raises:
+        ValueError: if validation finds blocking errors.
+    """
+    issues = validate_ai_prompt(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid AI prompt at {path}:\n{joined}")
+
+    prefix = (path / "prefix.txt").read_text(encoding="utf-8").strip()
+    suffixes: dict[str, str] = {}
+    for child in sorted(path.iterdir()):
+        m = _SUFFIX_RE.match(child.name)
+        if not m:
+            continue
+        orient = m.group("orient")
+        if orient in _SUPPORTED_ORIENTATIONS:
+            suffixes[orient] = child.read_text(encoding="utf-8").strip()
+    return AIPrompt(name=path.name, pack=pack, prefix=prefix, suffixes=suffixes)
+
+
+def load_ai_prompt(name: str, *, pack: str | None = None) -> AIPrompt:
+    """Convenience: resolve + load an AI prompt by name."""
+    from streamtex.core.artifacts.loaders import load_artifact
+    from streamtex.core.artifacts.spec import ArtifactKind
+
+    return load_artifact(name, ArtifactKind.AI_PROMPT, pack=pack)

--- a/streamtex/core/artifacts/archetype.py
+++ b/streamtex/core/artifacts/archetype.py
@@ -1,0 +1,160 @@
+"""Archetype artifact — markdown with YAML frontmatter.
+
+A scene archetype is a reusable visual composition pattern: "bridge",
+"horizon", "balance", etc. Each archetype is a markdown file with a YAML
+frontmatter that exposes its metadata machine-readably, while the body of
+the file documents the composition for human/agent consumption.
+
+Filesystem convention: ``<pack>/archetypes/<name>.md``
+
+Frontmatter schema (all but `palette_refs` required):
+
+    ---
+    name: bridge
+    description: Transition / 30-year horizon
+    orientation: landscape | portrait | square | any
+    status: validated | draft
+    tags: [transition, narrative]
+    extrapolable: true
+    since: 2026-05-05
+    palette_refs: [primary, accent, highlight]
+    ---
+
+Validation codes: ARV001-ARV010 (archetype validation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from streamtex.core.artifacts._frontmatter import split_frontmatter
+from streamtex.core.validation import ValidationIssue
+
+_REQUIRED_FIELDS = ("name", "description", "orientation", "status", "since")
+_VALID_ORIENTATIONS = {"landscape", "portrait", "square", "any"}
+_VALID_STATUSES = {"validated", "draft"}
+
+
+@dataclass(frozen=True)
+class Archetype:
+    """Typed view of an archetype artifact."""
+
+    name: str
+    pack: str
+    description: str
+    orientation: str
+    status: str
+    since: str
+    tags: list[str] = field(default_factory=list)
+    extrapolable: bool = True
+    palette_refs: list[str] = field(default_factory=list)
+    body: str = ""
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_archetype(path: Path) -> list[ValidationIssue]:
+    """Run validation checks on a single archetype markdown file.
+
+    ARV001 — file readable
+    ARV002 — has YAML frontmatter (opens with ---)
+    ARV003 — required fields present
+    ARV004 — `orientation` in {landscape, portrait, square, any}
+    ARV005 — `status` in {validated, draft}
+    ARV006 — `since` looks like ISO date YYYY-MM-DD
+    ARV007 — body is non-trivial (≥ 200 characters)
+    """
+    issues: list[ValidationIssue] = []
+    if not path.exists() or not path.is_file():
+        return [_issue("ARV001", "error", path, "archetype file not found")]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return [_issue("ARV001", "error", path, f"unreadable: {exc}")]
+
+    if not text.startswith("---"):
+        issues.append(_issue("ARV002", "error", path, "missing YAML frontmatter (file must open with `---`)"))
+        return issues
+
+    fm, body = split_frontmatter(text)
+    if not fm:
+        issues.append(_issue("ARV002", "error", path, "frontmatter is empty or malformed"))
+        return issues
+
+    for key in _REQUIRED_FIELDS:
+        if key not in fm or fm[key] in (None, ""):
+            issues.append(_issue("ARV003", "error", path, f"missing required field '{key}'"))
+
+    orient = fm.get("orientation")
+    if isinstance(orient, str) and orient not in _VALID_ORIENTATIONS:
+        issues.append(
+            _issue(
+                "ARV004",
+                "error",
+                path,
+                f"orientation {orient!r} not in {{{', '.join(sorted(_VALID_ORIENTATIONS))}}}",
+            )
+        )
+
+    status = fm.get("status")
+    if isinstance(status, str) and status not in _VALID_STATUSES:
+        issues.append(
+            _issue(
+                "ARV005",
+                "error",
+                path,
+                f"status {status!r} not in {{{', '.join(sorted(_VALID_STATUSES))}}}",
+            )
+        )
+
+    since = fm.get("since")
+    if isinstance(since, str):
+        import re
+        if not re.match(r"^\d{4}-\d{2}-\d{2}$", since):
+            issues.append(_issue("ARV006", "warning", path, f"since {since!r} not in YYYY-MM-DD format"))
+
+    if len(body.strip()) < 200:
+        issues.append(_issue("ARV007", "warning", path, "archetype body is suspiciously short (< 200 chars)"))
+
+    return issues
+
+
+def load_archetype_from_path(path: Path, *, pack: str = "") -> Archetype:
+    """Parse an archetype markdown file into a typed `Archetype` dataclass."""
+    issues = validate_archetype(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid archetype at {path}:\n{joined}")
+
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    tags = fm.get("tags") or []
+    if isinstance(tags, str):
+        tags = [tags]
+    palette_refs = fm.get("palette_refs") or []
+    if isinstance(palette_refs, str):
+        palette_refs = [palette_refs]
+    return Archetype(
+        name=str(fm.get("name") or path.stem),
+        pack=pack,
+        description=str(fm.get("description") or ""),
+        orientation=str(fm.get("orientation") or "any"),
+        status=str(fm.get("status") or "draft"),
+        since=str(fm.get("since") or ""),
+        tags=[str(t) for t in tags],
+        extrapolable=bool(fm.get("extrapolable", True)),
+        palette_refs=[str(r) for r in palette_refs],
+        body=body,
+    )
+
+
+def load_archetype(name: str, *, pack: str | None = None) -> Archetype:
+    """Convenience: resolve + load an archetype by name."""
+    from streamtex.core.artifacts.loaders import load_artifact
+    from streamtex.core.artifacts.spec import ArtifactKind
+
+    return load_artifact(name, ArtifactKind.ARCHETYPE, pack=pack)

--- a/streamtex/core/artifacts/asset.py
+++ b/streamtex/core/artifacts/asset.py
@@ -1,0 +1,140 @@
+"""Asset artifact — binary resources (logos, fonts, images, …) with a manifest.
+
+Filesystem convention: ``<pack>/assets/_manifest.toml`` + the binary files
+themselves. The manifest lists every shipped asset with its kind and
+license:
+
+    [[assets]]
+    path = "logos/gse-logo.svg"
+    kind = "logo"
+    license = "BUSL-1.1"
+    sha256 = "<optional>"
+
+The asset "name" in the [pack.data] section is the bundle name (typically
+just "assets"), pointing at the manifest. Individual asset paths are
+enumerated via the manifest entries.
+
+Validation codes: ASV001-ASV010 (asset validation).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from streamtex.core.validation import ValidationIssue
+
+_VALID_KINDS = {"logo", "font", "image", "icon", "audio", "video", "data", "other"}
+
+
+@dataclass(frozen=True)
+class AssetEntry:
+    """One entry in an asset manifest."""
+
+    path: str
+    kind: str
+    license: str
+    sha256: str = ""
+
+
+@dataclass(frozen=True)
+class AssetBundle:
+    """Typed view of a pack's ``assets/`` bundle (loaded from _manifest.toml)."""
+
+    name: str
+    pack: str
+    root: Path
+    entries: list[AssetEntry] = field(default_factory=list)
+
+    def resolve(self, asset_path: str) -> Path:
+        return self.root / asset_path
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_asset(path: Path) -> list[ValidationIssue]:
+    """Validate an asset bundle directory (or its `_manifest.toml`).
+
+    ASV001 — directory or manifest path exists
+    ASV002 — _manifest.toml parseable
+    ASV003 — [[assets]] entries are objects with path + kind + license
+    ASV004 — kinds within the supported set (warning if not)
+    ASV005 — each declared path exists on disk
+    """
+    issues: list[ValidationIssue] = []
+    if path.is_dir():
+        manifest = path / "_manifest.toml"
+        root = path
+    else:
+        manifest = path
+        root = path.parent
+    if not manifest.exists():
+        return [_issue("ASV001", "error", manifest, "asset manifest not found")]
+    try:
+        data = tomllib.loads(manifest.read_text())
+    except tomllib.TOMLDecodeError as exc:
+        return [_issue("ASV002", "error", manifest, f"manifest parse error: {exc}")]
+
+    entries = data.get("assets") or []
+    if not isinstance(entries, list) or not entries:
+        issues.append(_issue("ASV003", "warning", manifest, "[[assets]] is empty or missing"))
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            issues.append(_issue("ASV003", "error", manifest, f"entry must be a table: {entry!r}"))
+            continue
+        for field_name in ("path", "kind", "license"):
+            if not entry.get(field_name):
+                issues.append(
+                    _issue("ASV003", "error", manifest, f"asset entry missing '{field_name}'")
+                )
+        kind = entry.get("kind")
+        if isinstance(kind, str) and kind not in _VALID_KINDS:
+            issues.append(
+                _issue(
+                    "ASV004",
+                    "warning",
+                    manifest,
+                    f"kind {kind!r} not in {{{', '.join(sorted(_VALID_KINDS))}}}",
+                )
+            )
+        rel_path = entry.get("path")
+        if isinstance(rel_path, str):
+            on_disk = root / rel_path
+            if not on_disk.exists():
+                issues.append(
+                    _issue("ASV005", "error", manifest, f"asset file not found: {rel_path}")
+                )
+
+    return issues
+
+
+def load_asset_bundle_from_path(path: Path, *, pack: str = "") -> AssetBundle:
+    """Parse an asset bundle directory into a typed AssetBundle."""
+    issues = validate_asset(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid asset bundle at {path}:\n{joined}")
+
+    if path.is_dir():
+        manifest = path / "_manifest.toml"
+        root = path
+    else:
+        manifest = path
+        root = path.parent
+    data = tomllib.loads(manifest.read_text())
+    entries = [
+        AssetEntry(
+            path=e["path"],
+            kind=e["kind"],
+            license=e["license"],
+            sha256=e.get("sha256", ""),
+        )
+        for e in (data.get("assets") or [])
+        if isinstance(e, dict) and e.get("path")
+    ]
+    return AssetBundle(name=root.name, pack=pack, root=root, entries=entries)

--- a/streamtex/core/artifacts/discovery.py
+++ b/streamtex/core/artifacts/discovery.py
@@ -1,0 +1,174 @@
+"""Discovery of artifacts across the installed pack ecosystem.
+
+Walks the entry-points-registered packs, reads each pack's `_pack_manifest.toml`
+to learn which categories it declares under `[pack.data]`, then enumerates the
+artifact files/dirs on disk. No content is loaded at this stage.
+"""
+
+from __future__ import annotations
+
+import importlib
+import tomllib
+from pathlib import Path
+
+from streamtex.core import discovery as _pack_discovery
+from streamtex.core.artifacts.spec import (
+    KIND_FS,
+    KIND_MANIFEST_KEY,
+    ArtifactKind,
+    DiscoveredArtifact,
+)
+
+
+class ArtifactResolutionError(Exception):
+    """Raised when `resolve_artifact` cannot pick a unique winner."""
+
+    code: str = "AR000"
+
+
+def _pack_root(pack: _pack_discovery.DiscoveredPack) -> Path | None:
+    """Resolve the on-disk root of a discovered pack via its entry-point module."""
+    module_name = pack.entry_point_module
+    if not module_name:
+        return None
+    try:
+        mod = importlib.import_module(module_name)
+    except Exception:
+        return None
+    file = getattr(mod, "__file__", None)
+    if not file:
+        return None
+    return Path(file).resolve().parent
+
+
+def _read_pack_data_section(pack: _pack_discovery.DiscoveredPack) -> dict:
+    """Return the `[pack.data]` table from the pack manifest, or empty dict.
+
+    Format 0.1 packs (no [pack.data]) yield {} — they have no data-first
+    artifacts to enumerate.
+    """
+    root = _pack_root(pack)
+    if root is None:
+        return {}
+    manifest_path = root / "_pack_manifest.toml"
+    if not manifest_path.exists():
+        return {}
+    try:
+        data = tomllib.loads(manifest_path.read_text())
+    except tomllib.TOMLDecodeError:
+        return {}
+    pack_table = data.get("pack", {})
+    if isinstance(pack_table, dict):
+        data_section = pack_table.get("data", {})
+        if isinstance(data_section, dict):
+            return data_section
+    return {}
+
+
+def _scan_pack_artifacts(
+    pack: _pack_discovery.DiscoveredPack,
+    kind: ArtifactKind,
+) -> list[DiscoveredArtifact]:
+    """Enumerate artifacts of `kind` declared by `pack`."""
+    root = _pack_root(pack)
+    if root is None:
+        return []
+
+    data_section = _read_pack_data_section(pack)
+    manifest_key = KIND_MANIFEST_KEY[kind]
+    declared = data_section.get(manifest_key, [])
+    if not isinstance(declared, list):
+        return []
+
+    subdir_name, ext = KIND_FS[kind]
+    subdir = root / subdir_name
+    if not subdir.exists():
+        return []
+
+    out: list[DiscoveredArtifact] = []
+    for entry in declared:
+        if not isinstance(entry, str) or not entry:
+            continue
+        if ext is None:
+            # Subdir-based artifact (ai_prompt, asset, integration)
+            target = subdir / entry
+            if target.exists() and target.is_dir():
+                out.append(
+                    DiscoveredArtifact(
+                        name=entry, kind=kind, pack=pack.name, path=target
+                    )
+                )
+            elif kind == ArtifactKind.ASSET and target.name == "assets":
+                # Special case: assets/ as a whole, declared with "assets" or empty
+                pass
+        else:
+            target = subdir / f"{entry}{ext}"
+            if target.exists() and target.is_file():
+                out.append(
+                    DiscoveredArtifact(
+                        name=entry, kind=kind, pack=pack.name, path=target
+                    )
+                )
+    return out
+
+
+def discover_artifacts(
+    kind: ArtifactKind,
+    *,
+    pack: str | None = None,
+    stx_toml_path: Path | None = None,
+) -> list[DiscoveredArtifact]:
+    """Enumerate all artifacts of `kind` from installed packs.
+
+    Args:
+        kind: which artifact category to enumerate.
+        pack: optional pack name filter — return only artifacts from this pack.
+        stx_toml_path: optional path to a project stx.toml to use for pack
+            discovery (cf. `streamtex.core.discovery.discover_packs`).
+
+    Returns:
+        list of `DiscoveredArtifact`, possibly empty. Order: packs first by
+        `stx.toml` order, then by alphabetical artifact name within each pack.
+    """
+    packs = _pack_discovery.discover_packs(stx_toml_path=stx_toml_path)
+    out: list[DiscoveredArtifact] = []
+    for p in packs:
+        if pack is not None and p.name != pack:
+            continue
+        out.extend(_scan_pack_artifacts(p, kind))
+    return out
+
+
+def resolve_artifact(
+    name: str,
+    kind: ArtifactKind,
+    *,
+    prefer: list[str] | None = None,
+    stx_toml_path: Path | None = None,
+) -> DiscoveredArtifact:
+    """Return the unique artifact `(kind, name)` honoring resolution preference.
+
+    If multiple packs declare an artifact with the same name and kind, the
+    `prefer` list (defaults to project stx.toml `[resolution].prefer`) decides;
+    if none matches, the first-discovered wins.
+
+    Raises:
+        ArtifactResolutionError: if no artifact `(kind, name)` is found.
+    """
+    candidates = discover_artifacts(kind, stx_toml_path=stx_toml_path)
+    matches = [c for c in candidates if c.name == name]
+    if not matches:
+        err = ArtifactResolutionError(
+            f"No artifact of kind '{kind.value}' named '{name}' found across "
+            f"installed packs."
+        )
+        err.code = "AR001"
+        raise err
+    if len(matches) == 1:
+        return matches[0]
+    if prefer:
+        for preferred_pack in prefer:
+            for m in matches:
+                if m.pack == preferred_pack:
+                    return m
+    return matches[0]

--- a/streamtex/core/artifacts/guideline.py
+++ b/streamtex/core/artifacts/guideline.py
@@ -1,0 +1,149 @@
+"""Guideline artifact — markdown spec with R-numbered rules.
+
+A guideline captures opinionated rules that apply to components, archetypes,
+or projects (e.g. "R1 — one idea per slide", "R7 — center via parent block").
+Distinct from a *project blueprint* (which is pure AI guidance for scaffolding):
+a guideline is **opposable** — agents must respect it and humans cite it.
+
+Filesystem convention: ``<pack>/guidelines/<name>.md``
+
+Frontmatter schema:
+
+    ---
+    name: graphic-line
+    description: GSE visual identity spec
+    rules: [R1, R2, R7, R11, R12, R13]
+    applies_to: [components, archetypes, projects]
+    since: 2026-05-05
+    ---
+
+Validation codes: GLV001-GLV010 (guideline validation).
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from streamtex.core.artifacts._frontmatter import split_frontmatter
+from streamtex.core.validation import ValidationIssue
+
+_REQUIRED_FIELDS = ("name", "description", "since")
+_VALID_APPLIES_TO = {"components", "archetypes", "projects", "kits", "design_systems"}
+
+
+@dataclass(frozen=True)
+class Guideline:
+    """Typed view of a guideline artifact."""
+
+    name: str
+    pack: str
+    description: str
+    since: str
+    rules: list[str] = field(default_factory=list)
+    applies_to: list[str] = field(default_factory=list)
+    body: str = ""
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_guideline(path: Path) -> list[ValidationIssue]:
+    """Run validation checks on a single guideline markdown file.
+
+    GLV001 — file readable
+    GLV002 — has YAML frontmatter (opens with ---)
+    GLV003 — required fields present
+    GLV004 — `applies_to` items in the supported set (warning if not)
+    GLV005 — `rules` items are R-prefixed identifiers (warning if not)
+    GLV006 — body is non-trivial (≥ 200 characters)
+    """
+    issues: list[ValidationIssue] = []
+    if not path.exists() or not path.is_file():
+        return [_issue("GLV001", "error", path, "guideline file not found")]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return [_issue("GLV001", "error", path, f"unreadable: {exc}")]
+
+    if not text.startswith("---"):
+        issues.append(_issue("GLV002", "error", path, "missing YAML frontmatter"))
+        return issues
+
+    fm, body = split_frontmatter(text)
+    if not fm:
+        issues.append(_issue("GLV002", "error", path, "frontmatter is empty or malformed"))
+        return issues
+
+    for key in _REQUIRED_FIELDS:
+        if key not in fm or fm[key] in (None, ""):
+            issues.append(_issue("GLV003", "error", path, f"missing required field '{key}'"))
+
+    applies_to = fm.get("applies_to") or []
+    if isinstance(applies_to, list):
+        for item in applies_to:
+            if isinstance(item, str) and item not in _VALID_APPLIES_TO:
+                issues.append(
+                    _issue(
+                        "GLV004",
+                        "warning",
+                        path,
+                        f"applies_to item {item!r} not in canonical set "
+                        f"{{{', '.join(sorted(_VALID_APPLIES_TO))}}}",
+                    )
+                )
+
+    rules = fm.get("rules") or []
+    if isinstance(rules, list):
+        for r in rules:
+            if isinstance(r, str) and not re.match(r"^R\d+[a-z]?$", r):
+                issues.append(
+                    _issue(
+                        "GLV005",
+                        "warning",
+                        path,
+                        f"rule id {r!r} does not match expected pattern 'R<digits>[<letter>]'",
+                    )
+                )
+
+    if len(body.strip()) < 200:
+        issues.append(_issue("GLV006", "warning", path, "guideline body suspiciously short (< 200 chars)"))
+
+    return issues
+
+
+def load_guideline_from_path(path: Path, *, pack: str = "") -> Guideline:
+    """Parse a guideline markdown file into a typed `Guideline` dataclass."""
+    issues = validate_guideline(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid guideline at {path}:\n{joined}")
+
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    rules = fm.get("rules") or []
+    if isinstance(rules, str):
+        rules = [rules]
+    applies_to = fm.get("applies_to") or []
+    if isinstance(applies_to, str):
+        applies_to = [applies_to]
+    return Guideline(
+        name=str(fm.get("name") or path.stem),
+        pack=pack,
+        description=str(fm.get("description") or ""),
+        since=str(fm.get("since") or ""),
+        rules=[str(r) for r in rules],
+        applies_to=[str(a) for a in applies_to],
+        body=body,
+    )
+
+
+def load_guideline(name: str, *, pack: str | None = None) -> Guideline:
+    """Convenience: resolve + load a guideline by name."""
+    from streamtex.core.artifacts.loaders import load_artifact
+    from streamtex.core.artifacts.spec import ArtifactKind
+
+    return load_artifact(name, ArtifactKind.GUIDELINE, pack=pack)

--- a/streamtex/core/artifacts/install.py
+++ b/streamtex/core/artifacts/install.py
@@ -1,0 +1,129 @@
+"""Lifecycle hooks: install pack-shipped skills/agents into a project's
+`.claude/custom/` directory.
+
+Called by:
+- `stx artifact install <name> --kind skill|agent` (manual install)
+- `stx pack add <pack>` (Phase 4 — auto with confirmation prompt)
+
+Design constraints (EAR-4):
+- Confirmation prompt by default ; flag `--yes` to skip
+- Namespaced filename `<pack_slug>__<name>.md` to avoid collisions
+- Never read-only — users may edit their installed copy
+- Symmetric uninstall via `stx pack remove`
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from streamtex.core.artifacts.discovery import discover_artifacts, resolve_artifact
+from streamtex.core.artifacts.spec import ArtifactKind
+
+
+@dataclass
+class InstallReport:
+    """Result of installing one Claude artifact into a project."""
+
+    pack: str
+    name: str
+    kind: ArtifactKind
+    source: Path
+    destination: Path
+    action: str  # "installed" | "skipped" | "overwritten"
+
+
+def _target_subdir(kind: ArtifactKind) -> str:
+    if kind == ArtifactKind.SKILL:
+        return "skills"
+    if kind == ArtifactKind.AGENT:
+        return "agents"
+    raise ValueError(f"Unsupported kind for project install: {kind!r}")
+
+
+def _pack_slug(pack_name: str) -> str:
+    return pack_name.replace("streamtex-pack-", "").replace("-", "_")
+
+
+def install_claude_artifact(
+    name: str,
+    kind: ArtifactKind,
+    project_dir: Path,
+    *,
+    pack: str | None = None,
+    overwrite: bool = False,
+) -> InstallReport:
+    """Copy one skill/agent into `<project_dir>/.claude/custom/<subdir>/`.
+
+    Args:
+        name: artifact slug.
+        kind: must be SKILL or AGENT (other kinds are not installed in
+            `.claude/custom/`).
+        project_dir: project root containing (or about to contain) `.claude/`.
+        pack: optional disambiguation when multiple packs ship the same name.
+        overwrite: if False and target exists, skip (action="skipped").
+
+    Returns:
+        InstallReport describing what happened.
+    """
+    discovered = resolve_artifact(
+        name, kind, prefer=[pack] if pack else None
+    )
+    subdir = _target_subdir(kind)
+    pack_slug = _pack_slug(discovered.pack)
+    target_dir = project_dir / ".claude" / "custom" / subdir
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / f"{pack_slug}__{discovered.name}.md"
+
+    action = "installed"
+    if target.exists():
+        if not overwrite:
+            return InstallReport(
+                pack=discovered.pack,
+                name=discovered.name,
+                kind=kind,
+                source=discovered.path,
+                destination=target,
+                action="skipped",
+            )
+        action = "overwritten"
+
+    target.write_bytes(discovered.path.read_bytes())
+    return InstallReport(
+        pack=discovered.pack,
+        name=discovered.name,
+        kind=kind,
+        source=discovered.path,
+        destination=target,
+        action=action,
+    )
+
+
+def list_claude_artifacts_for_pack(pack_name: str) -> list[tuple[ArtifactKind, str]]:
+    """Return all `(kind, name)` pairs for skills + agents shipped by a pack.
+
+    Used by `stx pack add` (Phase 4) to know what to offer for install.
+    """
+    out: list[tuple[ArtifactKind, str]] = []
+    for kind in (ArtifactKind.SKILL, ArtifactKind.AGENT):
+        for art in discover_artifacts(kind, pack=pack_name):
+            out.append((kind, art.name))
+    return out
+
+
+def uninstall_claude_artifact(
+    pack_name: str,
+    name: str,
+    kind: ArtifactKind,
+    project_dir: Path,
+) -> bool:
+    """Remove a previously installed pack-skill/agent from a project.
+
+    Returns True if removed, False if file was not present.
+    """
+    pack_slug = _pack_slug(pack_name)
+    target = project_dir / ".claude" / "custom" / _target_subdir(kind) / f"{pack_slug}__{name}.md"
+    if target.exists():
+        target.unlink()
+        return True
+    return False

--- a/streamtex/core/artifacts/integration.py
+++ b/streamtex/core/artifacts/integration.py
@@ -1,0 +1,73 @@
+"""Integration recipe artifact — helper code per third-party framework.
+
+A pack may ship integration recipes for frameworks beyond streamtex itself
+(e.g. ``figma``, ``midjourney``). The recipe lives at
+``<pack>/integrations/<framework>/`` and is a free-form directory. The only
+contract for v0.2 is:
+
+* A ``README.md`` describing how to use the recipe.
+* Any number of supporting files (Python helpers, config templates, …).
+
+Validation codes: INV001-INV005 (integration validation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from streamtex.core.validation import ValidationIssue
+
+
+@dataclass(frozen=True)
+class Integration:
+    """Typed view of an integration recipe."""
+
+    name: str  # framework name (e.g. "streamtex", "figma")
+    pack: str
+    root: Path
+    readme: str = ""
+    files: list[str] = field(default_factory=list)
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_integration(path: Path) -> list[ValidationIssue]:
+    """Validate an integration recipe directory.
+
+    INV001 — directory exists
+    INV002 — README.md present
+    INV003 — README.md non-empty
+    """
+    issues: list[ValidationIssue] = []
+    if not path.exists() or not path.is_dir():
+        return [_issue("INV001", "error", path, "integration directory not found")]
+
+    readme = path / "README.md"
+    if not readme.exists():
+        issues.append(_issue("INV002", "error", path, "README.md is required"))
+    else:
+        try:
+            content = readme.read_text(encoding="utf-8").strip()
+            if not content:
+                issues.append(_issue("INV003", "warning", readme, "README.md is empty"))
+        except Exception as exc:
+            issues.append(_issue("INV003", "error", readme, f"unreadable: {exc}"))
+
+    return issues
+
+
+def load_integration_from_path(path: Path, *, pack: str = "") -> Integration:
+    """Parse an integration directory into an Integration record."""
+    issues = validate_integration(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid integration at {path}:\n{joined}")
+
+    readme_path = path / "README.md"
+    readme_text = readme_path.read_text(encoding="utf-8") if readme_path.exists() else ""
+    files = [p.name for p in sorted(path.iterdir()) if p.is_file()]
+    return Integration(name=path.name, pack=pack, root=path, readme=readme_text, files=files)

--- a/streamtex/core/artifacts/loaders.py
+++ b/streamtex/core/artifacts/loaders.py
@@ -1,0 +1,57 @@
+"""Typed loader dispatch for the generic artifact engine.
+
+`load_artifact(name, kind, *, pack=None)` resolves the artifact via the engine
+discovery layer, then loads its typed view (a `dataclass` or TypedDict-shaped
+object) by delegating to the per-category module.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from streamtex.core.artifacts.discovery import resolve_artifact
+from streamtex.core.artifacts.spec import ArtifactKind
+
+
+def load_artifact(
+    name: str,
+    kind: ArtifactKind,
+    *,
+    pack: str | None = None,
+    stx_toml_path: Path | None = None,
+) -> Any:
+    """Load the typed Python view of an artifact.
+
+    Args:
+        name: artifact name (slug).
+        kind: which category.
+        pack: optional pack name filter (use to disambiguate when more than
+            one pack declares the same name).
+        stx_toml_path: optional project stx.toml path for discovery.
+
+    Returns:
+        The kind-specific dataclass/TypedDict (e.g. `Palette` for
+        ArtifactKind.PALETTE). See per-category module for the exact type.
+
+    Raises:
+        ArtifactResolutionError: if the artifact is not found.
+    """
+    discovered = resolve_artifact(
+        name,
+        kind,
+        prefer=[pack] if pack else None,
+        stx_toml_path=stx_toml_path,
+    )
+    if kind == ArtifactKind.PALETTE:
+        from streamtex.core.artifacts.palette import load_palette_from_path
+
+        return load_palette_from_path(discovered.path, pack=discovered.pack)
+    if kind == ArtifactKind.AI_PROMPT:
+        from streamtex.core.artifacts.ai_prompt import load_ai_prompt_from_path
+
+        return load_ai_prompt_from_path(discovered.path, pack=discovered.pack)
+    raise NotImplementedError(
+        f"load_artifact does not yet support kind={kind.value!r}; "
+        "the per-category loader has not been registered."
+    )

--- a/streamtex/core/artifacts/loaders.py
+++ b/streamtex/core/artifacts/loaders.py
@@ -51,6 +51,30 @@ def load_artifact(
         from streamtex.core.artifacts.ai_prompt import load_ai_prompt_from_path
 
         return load_ai_prompt_from_path(discovered.path, pack=discovered.pack)
+    if kind == ArtifactKind.ARCHETYPE:
+        from streamtex.core.artifacts.archetype import load_archetype_from_path
+
+        return load_archetype_from_path(discovered.path, pack=discovered.pack)
+    if kind == ArtifactKind.GUIDELINE:
+        from streamtex.core.artifacts.guideline import load_guideline_from_path
+
+        return load_guideline_from_path(discovered.path, pack=discovered.pack)
+    if kind == ArtifactKind.SKILL:
+        from streamtex.core.artifacts.skill import load_skill_from_path
+
+        return load_skill_from_path(discovered.path, pack=discovered.pack)
+    if kind == ArtifactKind.AGENT:
+        from streamtex.core.artifacts.agent import load_agent_from_path
+
+        return load_agent_from_path(discovered.path, pack=discovered.pack)
+    if kind == ArtifactKind.ASSET:
+        from streamtex.core.artifacts.asset import load_asset_bundle_from_path
+
+        return load_asset_bundle_from_path(discovered.path, pack=discovered.pack)
+    if kind == ArtifactKind.INTEGRATION:
+        from streamtex.core.artifacts.integration import load_integration_from_path
+
+        return load_integration_from_path(discovered.path, pack=discovered.pack)
     raise NotImplementedError(
         f"load_artifact does not yet support kind={kind.value!r}; "
         "the per-category loader has not been registered."

--- a/streamtex/core/artifacts/palette.py
+++ b/streamtex/core/artifacts/palette.py
@@ -1,0 +1,225 @@
+"""Palette artifact — JSON canonical, Python view generated at load time.
+
+A palette file lives at `<pack>/palettes/<name>.json` with the schema:
+
+    {
+      "name": "main",
+      "version": "1.0.0",
+      "colors": {
+        "<token>": {
+          "hex": "#RRGGBB",
+          "role": "<short description>",
+          "constraints": "<optional usage constraints>"
+        }
+      },
+      "dimensions": {
+        "<dimension_name>": "<color_token>"
+      }
+    }
+
+The Python view (`Palette` dataclass) exposes:
+
+* `colors: dict[str, Color]` — keyed by token name. Each `Color` carries the
+  hex string, role/constraints metadata, plus an `as_style()` method that
+  returns a composable `streamtex.styles.Style` atom.
+* `dimensions: dict[str, str]` — semantic aliases (e.g. "ideological" → "primary").
+
+Validation codes: PAV001–PAV010 (`palette artifact validation`).
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from streamtex.core.validation import ValidationIssue
+
+_HEX_RE = re.compile(r"^#[0-9A-Fa-f]{6}$")
+
+
+@dataclass(frozen=True)
+class Color:
+    """One palette entry — hex string + role metadata + Style adapter."""
+
+    token: str
+    hex: str
+    role: str = ""
+    constraints: str = ""
+
+    def as_style(self, *, style_id: str | None = None):
+        """Return a composable `streamtex.styles.Style` atom (color property).
+
+        Import is lazy to keep `streamtex.core.artifacts` importable without
+        loading the styles subsystem.
+        """
+        from streamtex.styles import Style
+
+        return Style(f"color: {self.hex};", style_id or f"color_{self.token}")
+
+    def as_bg_style(self, *, style_id: str | None = None):
+        """Same as `as_style` but emits a background-color CSS property."""
+        from streamtex.styles import Style
+
+        return Style(f"background-color: {self.hex};", style_id or f"bg_{self.token}")
+
+
+@dataclass(frozen=True)
+class Palette:
+    """Typed Python view of a palette artifact."""
+
+    name: str
+    pack: str
+    version: str
+    colors: dict[str, Color]
+    dimensions: dict[str, str] = field(default_factory=dict)
+    since: str = ""
+
+    def hex_for(self, name: str) -> str:
+        """Return the hex string for a token or dimension name.
+
+        Resolves dimensions transitively (`hex_for("ideological")` →
+        `colors["primary"].hex` if `dimensions["ideological"] == "primary"`).
+        """
+        if name in self.dimensions:
+            name = self.dimensions[name]
+        if name not in self.colors:
+            raise KeyError(
+                f"Palette {self.pack}:{self.name}: unknown color or dimension "
+                f"{name!r}. Known colors: {sorted(self.colors)}; "
+                f"known dimensions: {sorted(self.dimensions)}."
+            )
+        return self.colors[name].hex
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_palette(path: Path) -> list[ValidationIssue]:
+    """Run validation checks on a single palette JSON file.
+
+    PAV001 — file readable
+    PAV002 — valid JSON
+    PAV003 — top-level object (dict)
+    PAV004 — `name` field present and non-empty string
+    PAV005 — `version` field present, semver-ish string
+    PAV006 — `colors` table present and non-empty
+    PAV007 — every color entry is an object with hex
+    PAV008 — every hex matches `#RRGGBB`
+    PAV009 — dimensions (if present) point to existing color tokens
+    PAV010 — no duplicate or shadowed keys
+    """
+    issues: list[ValidationIssue] = []
+    if not path.exists():
+        return [_issue("PAV001", "error", path, "palette file not found")]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return [_issue("PAV001", "error", path, f"palette file unreadable: {exc}")]
+    try:
+        data: Any = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return [_issue("PAV002", "error", path, f"invalid JSON: {exc}")]
+    if not isinstance(data, dict):
+        return [_issue("PAV003", "error", path, "top-level must be an object")]
+
+    name = data.get("name")
+    if not isinstance(name, str) or not name:
+        issues.append(_issue("PAV004", "error", path, "missing or empty 'name'"))
+
+    version = data.get("version")
+    if not isinstance(version, str) or not version:
+        issues.append(_issue("PAV005", "error", path, "missing or empty 'version'"))
+
+    colors = data.get("colors")
+    if not isinstance(colors, dict) or not colors:
+        issues.append(_issue("PAV006", "error", path, "'colors' must be a non-empty object"))
+        colors = {}
+
+    for token, entry in colors.items():
+        if not isinstance(entry, dict):
+            issues.append(
+                _issue("PAV007", "error", path, f"color {token!r} must be an object")
+            )
+            continue
+        hex_value = entry.get("hex")
+        if not isinstance(hex_value, str) or not _HEX_RE.match(hex_value):
+            issues.append(
+                _issue(
+                    "PAV008",
+                    "error",
+                    path,
+                    f"color {token!r}: hex {hex_value!r} must match '#RRGGBB'",
+                )
+            )
+
+    dimensions = data.get("dimensions") or {}
+    if isinstance(dimensions, dict):
+        for dim, target in dimensions.items():
+            if dim.startswith("_"):
+                continue
+            if not isinstance(target, str) or target not in colors:
+                issues.append(
+                    _issue(
+                        "PAV009",
+                        "error",
+                        path,
+                        f"dimension {dim!r} points to unknown color {target!r}",
+                    )
+                )
+
+    return issues
+
+
+def load_palette_from_path(path: Path, *, pack: str = "") -> Palette:
+    """Parse a palette JSON file into a typed `Palette` dataclass.
+
+    Raises:
+        ValueError: if the file is not a valid palette (validation errors).
+    """
+    issues = validate_palette(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid palette at {path}:\n{joined}")
+
+    data = json.loads(path.read_text(encoding="utf-8"))
+    name = data.get("name", path.stem)
+    version = data.get("version", "0.0.0")
+    raw_colors = data.get("colors", {})
+    colors: dict[str, Color] = {}
+    for token, entry in raw_colors.items():
+        colors[token] = Color(
+            token=token,
+            hex=entry["hex"],
+            role=entry.get("role", ""),
+            constraints=entry.get("constraints", ""),
+        )
+    raw_dimensions = data.get("dimensions") or {}
+    dimensions = {
+        k: v for k, v in raw_dimensions.items()
+        if isinstance(k, str) and isinstance(v, str) and not k.startswith("_")
+    }
+    return Palette(
+        name=name,
+        pack=pack,
+        version=version,
+        colors=colors,
+        dimensions=dimensions,
+        since=data.get("since", ""),
+    )
+
+
+def load_palette(name: str, *, pack: str | None = None) -> Palette:
+    """Convenience: resolve + load a palette by name.
+
+    Equivalent to:
+        load_artifact(name, ArtifactKind.PALETTE, pack=pack)
+    """
+    from streamtex.core.artifacts.loaders import load_artifact
+    from streamtex.core.artifacts.spec import ArtifactKind
+
+    return load_artifact(name, ArtifactKind.PALETTE, pack=pack)

--- a/streamtex/core/artifacts/skill.py
+++ b/streamtex/core/artifacts/skill.py
@@ -1,0 +1,113 @@
+"""Skill artifact — Claude Code skill, pack-scoped.
+
+A skill is a markdown file with Claude Code frontmatter (``name`` +
+``description``) that ships inside a pack. At ``stx pack add <pack>``, the
+skill is copied (with confirmation prompt) to the project's
+``.claude/custom/skills/<pack>__<name>.md`` so the agent can discover it.
+
+The namespace ``<pack>:<name>`` (or filename ``<pack>__<name>.md``) prevents
+collisions across packs.
+
+Filesystem convention: ``<pack>/skills/<name>.md``
+
+Frontmatter schema:
+
+    ---
+    name: gse-author
+    description: Skill helping authors write content in the GSE register
+    ---
+
+Validation codes: SKV001-SKV010 (skill validation).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from streamtex.core.artifacts._frontmatter import split_frontmatter
+from streamtex.core.validation import ValidationIssue
+
+_REQUIRED_FIELDS = ("name", "description")
+
+
+@dataclass(frozen=True)
+class Skill:
+    """Typed view of a Claude Code skill artifact."""
+
+    name: str
+    pack: str
+    description: str
+    body: str
+
+    @property
+    def namespaced_name(self) -> str:
+        """Globally unique slug used when installed into a project."""
+        return f"{self.pack}:{self.name}"
+
+    @property
+    def install_filename(self) -> str:
+        """Filename used when copied to ``.claude/custom/skills/``."""
+        pack_slug = self.pack.replace("streamtex-pack-", "").replace("-", "_")
+        return f"{pack_slug}__{self.name}.md"
+
+
+def _issue(code: str, severity: str, path: Path, message: str) -> ValidationIssue:
+    return ValidationIssue(code=code, severity=severity, location=str(path), message=message)
+
+
+def validate_skill(path: Path) -> list[ValidationIssue]:
+    """Run validation checks on a single skill markdown file.
+
+    SKV001 — file readable
+    SKV002 — has YAML frontmatter
+    SKV003 — required fields present
+    SKV004 — body is non-trivial (≥ 100 chars)
+    """
+    issues: list[ValidationIssue] = []
+    if not path.exists() or not path.is_file():
+        return [_issue("SKV001", "error", path, "skill file not found")]
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception as exc:
+        return [_issue("SKV001", "error", path, f"unreadable: {exc}")]
+
+    if not text.startswith("---"):
+        issues.append(_issue("SKV002", "error", path, "missing YAML frontmatter"))
+        return issues
+
+    fm, body = split_frontmatter(text)
+    for key in _REQUIRED_FIELDS:
+        if key not in fm or fm[key] in (None, ""):
+            issues.append(_issue("SKV003", "error", path, f"missing required field '{key}'"))
+
+    if len(body.strip()) < 100:
+        issues.append(_issue("SKV004", "warning", path, "skill body suspiciously short (< 100 chars)"))
+
+    return issues
+
+
+def load_skill_from_path(path: Path, *, pack: str = "") -> Skill:
+    """Parse a skill markdown file into a typed `Skill` dataclass."""
+    issues = validate_skill(path)
+    blocking = [i for i in issues if i.is_error()]
+    if blocking:
+        joined = "\n".join(f"  [{i.code}] {i.message}" for i in blocking)
+        raise ValueError(f"Invalid skill at {path}:\n{joined}")
+
+    text = path.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    return Skill(
+        name=str(fm.get("name") or path.stem),
+        pack=pack,
+        description=str(fm.get("description") or ""),
+        body=body,
+    )
+
+
+def load_skill(name: str, *, pack: str | None = None) -> Skill:
+    """Convenience: resolve + load a skill by name."""
+    from streamtex.core.artifacts.loaders import load_artifact
+    from streamtex.core.artifacts.spec import ArtifactKind
+
+    return load_artifact(name, ArtifactKind.SKILL, pack=pack)

--- a/streamtex/core/artifacts/spec.py
+++ b/streamtex/core/artifacts/spec.py
@@ -1,0 +1,78 @@
+"""Shared types for the generic artifact engine."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Protocol, runtime_checkable
+
+
+class ArtifactKind(str, Enum):
+    """Supported artifact categories under `[pack.data]` (manifest 0.2+)."""
+
+    PALETTE = "palette"
+    AI_PROMPT = "ai_prompt"
+    ARCHETYPE = "archetype"
+    GUIDELINE = "guideline"
+    SKILL = "skill"
+    AGENT = "agent"
+    ASSET = "asset"
+    INTEGRATION = "integration"
+
+
+# Per-kind filesystem conventions: (subdir, file_extension OR None for dirs)
+KIND_FS: dict[ArtifactKind, tuple[str, str | None]] = {
+    ArtifactKind.PALETTE: ("palettes", ".json"),
+    ArtifactKind.AI_PROMPT: ("ai_prompts", None),       # subdir per prompt
+    ArtifactKind.ARCHETYPE: ("archetypes", ".md"),
+    ArtifactKind.GUIDELINE: ("guidelines", ".md"),
+    ArtifactKind.SKILL: ("skills", ".md"),
+    ArtifactKind.AGENT: ("agents", ".md"),
+    ArtifactKind.ASSET: ("assets", None),               # whole dir + _manifest.toml
+    ArtifactKind.INTEGRATION: ("integrations", None),   # subdir per framework
+}
+
+
+# Per-kind manifest keys under [pack.data]
+KIND_MANIFEST_KEY: dict[ArtifactKind, str] = {
+    ArtifactKind.PALETTE: "palettes",
+    ArtifactKind.AI_PROMPT: "ai_prompts",
+    ArtifactKind.ARCHETYPE: "archetypes",
+    ArtifactKind.GUIDELINE: "guidelines",
+    ArtifactKind.SKILL: "skills",
+    ArtifactKind.AGENT: "agents",
+    ArtifactKind.ASSET: "assets",
+    ArtifactKind.INTEGRATION: "integrations",
+}
+
+
+@runtime_checkable
+class ArtifactSpec(Protocol):
+    """Minimal common shape of a typed artifact loaded from disk.
+
+    Each category extends this with its own fields (palette has `colors`,
+    archetype has `composition`, etc.).
+    """
+
+    name: str
+    pack: str
+    kind: ArtifactKind
+    since: str  # ISO date "YYYY-MM-DD"
+
+
+@dataclass(frozen=True)
+class DiscoveredArtifact:
+    """Uniform record returned by `discover_artifacts`.
+
+    Carries enough metadata to locate the artifact on disk without yet loading
+    its content — keeps discovery cheap and side-effect-free.
+    """
+
+    name: str
+    kind: ArtifactKind
+    pack: str
+    path: Path
+
+    def __repr__(self) -> str:
+        return f"DiscoveredArtifact({self.pack}:{self.name}, kind={self.kind.value})"

--- a/streamtex/core/artifacts/validation.py
+++ b/streamtex/core/artifacts/validation.py
@@ -28,7 +28,28 @@ def validate_artifact(path: Path, kind: ArtifactKind) -> list[ValidationIssue]:
         from streamtex.core.artifacts.ai_prompt import validate_ai_prompt
 
         return validate_ai_prompt(path)
-    # Other kinds will be added in subsequent phases (archetype, guideline,
-    # skill, agent, asset, integration). For now return empty — the file
-    # exists check is done at discovery time.
+    if kind == ArtifactKind.ARCHETYPE:
+        from streamtex.core.artifacts.archetype import validate_archetype
+
+        return validate_archetype(path)
+    if kind == ArtifactKind.GUIDELINE:
+        from streamtex.core.artifacts.guideline import validate_guideline
+
+        return validate_guideline(path)
+    if kind == ArtifactKind.SKILL:
+        from streamtex.core.artifacts.skill import validate_skill
+
+        return validate_skill(path)
+    if kind == ArtifactKind.AGENT:
+        from streamtex.core.artifacts.agent import validate_agent
+
+        return validate_agent(path)
+    if kind == ArtifactKind.ASSET:
+        from streamtex.core.artifacts.asset import validate_asset
+
+        return validate_asset(path)
+    if kind == ArtifactKind.INTEGRATION:
+        from streamtex.core.artifacts.integration import validate_integration
+
+        return validate_integration(path)
     return []

--- a/streamtex/core/artifacts/validation.py
+++ b/streamtex/core/artifacts/validation.py
@@ -1,0 +1,34 @@
+"""Validation dispatch for the generic artifact engine.
+
+`validate_artifact(path, kind)` dispatches on the kind to the per-category
+validator. Each per-category validator is owned by its sibling module
+(`palette.py::validate_palette`, etc.) and returns a list of
+`ValidationIssue` from `streamtex.core.validation`.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from streamtex.core.artifacts.spec import ArtifactKind
+from streamtex.core.validation import ValidationIssue
+
+
+def validate_artifact(path: Path, kind: ArtifactKind) -> list[ValidationIssue]:
+    """Validate a single artifact at `path`, dispatching on `kind`.
+
+    Lazy imports per-category modules so adding a new kind only touches that
+    module + the spec enum + this dispatch table.
+    """
+    if kind == ArtifactKind.PALETTE:
+        from streamtex.core.artifacts.palette import validate_palette
+
+        return validate_palette(path)
+    if kind == ArtifactKind.AI_PROMPT:
+        from streamtex.core.artifacts.ai_prompt import validate_ai_prompt
+
+        return validate_ai_prompt(path)
+    # Other kinds will be added in subsequent phases (archetype, guideline,
+    # skill, agent, asset, integration). For now return empty — the file
+    # exists check is done at discovery time.
+    return []

--- a/streamtex/core/contracts.py
+++ b/streamtex/core/contracts.py
@@ -240,11 +240,33 @@ class PackInfo(TypedDict):
     streamtex_compat: str
 
 
+class PackDataSection(TypedDict, total=False):
+    """Optional `[pack.data]` table (manifest 0.2+).
+
+    Each key lists the artifact names of a given category that the pack ships.
+    The list is the source-of-truth for discovery: an unlisted file on disk is
+    not enumerated. Categories absent from this dict mean the pack does not
+    provide that artifact kind.
+
+    Cross-references: `streamtex.core.artifacts.spec.ArtifactKind`.
+    """
+
+    palettes: list[str]
+    ai_prompts: list[str]
+    archetypes: list[str]
+    guidelines: list[str]
+    skills: list[str]
+    agents: list[str]
+    assets: list[str]
+    integrations: list[str]
+
+
 class PackManifest(TypedDict):
     manifest: ManifestFormat
     pack: PackInfo
     entrypoint: PackEntrypoint
     scopes: NotRequired[dict]
+    data: NotRequired[PackDataSection]  # manifest 0.2+, optional
 
 
 # ---------------------------------------------------------------------------
@@ -299,6 +321,7 @@ __all__ = [
     "KitSpec",
     "KitManifest",
     "ManifestFormat",
+    "PackDataSection",
     "PackEntrypoint",
     "PackInfo",
     "PackManifest",


### PR DESCRIPTION
## Summary

Introduces a **generic artifact engine** in `streamtex.core.artifacts` that
unlocks 8 new categories of pack artifacts under an additive `[pack.data]`
section in `_pack_manifest.toml` (format **0.2**):

- **palette** — JSON canonical, Python view at import (composable Style atoms)
- **ai_prompt** — prefix + per-orientation suffixes for AI image generation
- **archetype** — markdown + YAML frontmatter, reusable visual scene patterns
- **guideline** — markdown + YAML frontmatter, opposable R-rules
- **skill** — pack-scoped Claude Code skill (lifecycle: install to `.claude/custom/`)
- **agent** — pack-scoped Claude Code agent
- **asset** — `_manifest.toml` + binary files with license tracking
- **integration** — open-contract recipe per third-party framework

Each category ships:
- A TypedDict / dataclass for its content view
- A validator with dedicated error codes (PAV/APV/ARV/GLV/SKV/AGV/ASV/INV)
- A typed loader (lazy import to keep engine startup cheap)

CLI: new `stx artifact list|show|validate|install [--kind <k>] [--pack <p>]`,
backward compatible with existing `stx pack/component/ds/kit` surface.

## Test plan
- [x] 2192 existing tests pass (no regression)
- [x] Ruff clean across the new modules + CLI
- [x] End-to-end: `stx artifact list` enumerates 17 artifacts in `streamtex-pack-gse v2.0.0` (palette + ai_prompt + 11 archetypes + 2 guidelines + 1 skill + 1 integration)
- [x] `stx artifact validate` returns OK on all 17 with this branch

## Backward compatibility
- Format 0.1 packs (`pack-design v0.3.0`, `pack-manuals v0.2.0`) unaffected.
- No `[pack.data]` section in a 0.2 pack = behaves exactly like a 0.1 pack.

## Sister PRs
- `streamtex-packs` — pack-gse v2.0 migration consuming the new engine
- `streamtex-claude` — reuse-architecture skill documenting the 8 categories

## RFC
Local document `documentation/maintenance/design-packs/RFC-extended-artifacts.md`
records 10 design decisions (EAR-1 … EAR-10). Not in repo (gitignored
maintenance dir).

🤖 Generated with [Claude Code](https://claude.com/claude-code)