### PR TITLE
chore: release 0.7.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.17] — 2026-05-26 — generic artifact engine (manifest 0.2)
+
+### Added
+
+- **`streamtex.core.artifacts` subpackage** — generic engine for extended
+  pack artifacts under the additive `[pack.data]` section of manifest
+  format **0.2**. Eight categories supported:
+  - `palette` — JSON canonical, Python view at import (composable Style atoms)
+  - `ai_prompt` — prefix + per-orientation suffixes for AI image generation
+  - `archetype` — markdown + YAML frontmatter, reusable visual scene patterns
+  - `guideline` — markdown + YAML frontmatter, opposable R-rules
+  - `skill` / `agent` — pack-scoped Claude Code skill/agent (install hook
+    to `.claude/custom/<subdir>/<pack_slug>__<name>.md`)
+  - `asset` — `_manifest.toml` + binary files with license tracking
+  - `integration` — open-contract recipe per third-party framework
+- Per-category modules (`palette.py`, `ai_prompt.py`, …) each ship a
+  TypedDict / dataclass view, a dedicated validator (`PAV*` / `APV*` /
+  `ARV*` / `GLV*` / `SKV*` / `AGV*` / `ASV*` / `INV*` codes), and a
+  typed loader.
+- `streamtex/cli/artifact_cmd.py` — new CLI surface
+  `stx artifact list|show|validate|install [--kind <k>] [--pack <p>]`.
+- Lifecycle hook for skills/agents: `install_claude_artifact()` copies
+  pack-shipped Claude artifacts into `<project>/.claude/custom/` with a
+  namespaced filename. Confirmation prompt by default at the CLI;
+  `--yes` to skip.
+- `contracts.PackManifest` gains optional `PackDataSection` (TypedDict).
+- Reference example: `streamtex-pack-gse v2.0.0` ships 17 artifacts
+  across 6 of the 8 categories.
+
+### Notes
+
+- Format **0.2** is additive. Existing format-0.1 packs (pack-design
+  v0.3.0, pack-manuals v0.2.0) work unchanged. A 0.2 pack with no
+  `[pack.data]` section is identical to a 0.1 pack.
+- Supersedes the now-removed `streamtex-shared/graphic-designs/gse/`
+  legacy file-copy system.
+
 ## [0.7.16] — 2026-05-25 — optional `FontsBundle` Protocol + `stx --help` quick-start
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "streamtex"
-version = "0.7.16"
+version = "0.7.17"
 description = "AI-powered content framework for Streamlit — create presentations, courses, and web-books with Claude or Cursor, no coding required."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Bumps streamtex to **0.7.17** to surface the new `streamtex.core.artifacts`
engine (manifest 0.2 extended pack artifacts) to PyPI consumers.

## Why now

`streamtex-pack-gse v2.0.0` (just tagged) imports
`streamtex.core.artifacts.palette.load_palette_from_path` at design
system construction time. Without this release, `pip install
streamtex-pack-gse==2.0.0` fails at import on a machine that only has
streamtex 0.7.16 from PyPI.

## What's in 0.7.17

Just the merge of #29 — see the CHANGELOG entry for the full breakdown
of the 8 new artifact categories, validators, CLI surface, and lifecycle
hooks.

## Release pipeline

This merge to main bumps pyproject.toml → auto-tag workflow creates
the `v0.7.17` tag + GitHub release → publish workflow uploads to PyPI.

## Test plan
- [x] 2192 existing tests pass (already verified at #29 merge)
- [ ] After PyPI publish, smoke-test: `pip install streamtex==0.7.17 streamtex-pack-gse==2.0.0` then `python -c "from streamtex_gse.design_systems.gse import DesignSystem; print(DesignSystem.colors.primary.css)"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)